### PR TITLE
ci: bump actions to v6 to silence Node 20 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
                 node-version: [20.x, 22.x, 25.x]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: pnpm


### PR DESCRIPTION
GitHub flagged actions/checkout@v4, pnpm/action-setup@v4, and actions/setup-node@v4 — all run on Node.js 20 internally, which is forced to Node 24 on 2026-06-16 and removed on 2026-09-16. v6 of each runs on Node 24.

Same inputs, no other changes. shared-bump.yml in package-test-utils still has actions/setup-node@v3 and needs a separate bump there.