### PR TITLE
docs: move immer-reduxer under a Deprecated subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ This libs are using [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/wor
 
 ## Workspaces
 
-- [immer-reduxer](./packages/immer-reduxer/README.md)
 - [find-js](./packages/find-js/README.md)
 - [abonnement-js](./packages/abonnement-js/README.md)
 - [array.utils](./packages/array.utils/README.md)
 - [git-prompt](./packages/git-prompt/README.md)
 
 [//]: <> (package-list-placeholder-do-not-remove)
+
+### Deprecated
+
+No longer maintained. Pin an existing version if you need them; do not adopt them for new projects.
+
+- [immer-reduxer](./packages/immer-reduxer/README.md)
 
 ## Install
 


### PR DESCRIPTION
## Summary

The `immer-reduxer` package README has carried a "no longer maintained" deprecation notice for some time. The root README still listed it alongside the active packages, which is misleading for anyone landing on the repo.

Move it under a new `### Deprecated` subsection so the main Workspaces list only shows packages we actually maintain.

## Notes

- The `Deprecated` subsection is placed **after** the `[//]: <> (package-list-placeholder-do-not-remove)` marker. `scripts/generate.js` inserts new active packages immediately before that marker, so the deprecated list stays untouched as new packages are scaffolded.
- The package itself is unchanged — still in `packages/immer-reduxer/`, still buildable, still in the lockfile. This is documentation only.

## Test plan

- [x] `pnpm run pre-commit` green on the branch
- [x] CI green