### PR TITLE
docs: add npm + Snyk + bundle-size badges to active package READMEs

### DIFF
--- a/packages/abonnement-js/README.md
+++ b/packages/abonnement-js/README.md
@@ -1,5 +1,9 @@
 # abonnement-js
 
+[![npm version](https://img.shields.io/npm/v/@hansogj/abonnement-js)](https://www.npmjs.com/package/@hansogj/abonnement-js)
+[![known vulnerabilities](https://snyk.io/test/npm/@hansogj/abonnement-js/badge.svg)](https://snyk.io/test/npm/@hansogj/abonnement-js)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@hansogj/abonnement-js)](https://bundlephobia.com/package/@hansogj/abonnement-js)
+
 lightweight, naive, event susbscription
 
 ## Simple excample

--- a/packages/array.utils/README.md
+++ b/packages/array.utils/README.md
@@ -1,5 +1,9 @@
 # ARRAY.UTILS
 
+[![npm version](https://img.shields.io/npm/v/@hansogj/array.utils)](https://www.npmjs.com/package/@hansogj/array.utils)
+[![known vulnerabilities](https://snyk.io/test/npm/@hansogj/array.utils/badge.svg)](https://snyk.io/test/npm/@hansogj/array.utils)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@hansogj/array.utils)](https://bundlephobia.com/package/@hansogj/array.utils)
+
 List of content:
 
 -   [defined](./src/defined/README.md)

--- a/packages/find-js/README.md
+++ b/packages/find-js/README.md
@@ -1,5 +1,9 @@
 # find-js
 
+[![npm version](https://img.shields.io/npm/v/@hansogj/find-js)](https://www.npmjs.com/package/@hansogj/find-js)
+[![known vulnerabilities](https://snyk.io/test/npm/@hansogj/find-js/badge.svg)](https://snyk.io/test/npm/@hansogj/find-js)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@hansogj/find-js)](https://bundlephobia.com/package/@hansogj/find-js)
+
 Returns an iterable array of node-elements.
 
 ## Usage

--- a/packages/git-prompt/README.md
+++ b/packages/git-prompt/README.md
@@ -1,5 +1,8 @@
 # GIT-PROMPT
 
+[![npm version](https://img.shields.io/npm/v/@hansogj/git-prompt)](https://www.npmjs.com/package/@hansogj/git-prompt)
+[![known vulnerabilities](https://snyk.io/test/npm/@hansogj/git-prompt/badge.svg)](https://snyk.io/test/npm/@hansogj/git-prompt)
+
 Simple generator of branch names and commit messages. 
 
 ### Checkout


### PR DESCRIPTION
## Summary

Each of the four maintained packages now carries a three-badge strip at the top of its README:

- **npm version** (shields.io) — current published version, click-through to npm
- **known vulnerabilities** (Snyk public scan) — turns red if the dep tree has known CVEs
- **bundle size** (bundlephobia, minified+gzip) — skipped for `git-prompt` since it ships CLI binaries, not a library bundle

`immer-reduxer` is intentionally left alone — deprecated; #32 moves it out of the active Workspaces list.

All badge endpoints are public; no Snyk or bundlephobia account/token required.

## Why per-package and not root README

Root README's CI badge already covers monorepo-wide build status. Per-package badges live in the package's own README so consumers landing there from npm or a search result see version/security/size at a glance.

## Test plan

- [x] `pnpm run pre-commit` green on the branch
- [x] CI green
- [x] Visually verify the badges render correctly on GitHub after merge (a couple of them may show "unknown" the first time Snyk/bundlephobia indexes them — they self-heal within minutes)