### PR TITLE
feat: integrate @hansogj/maybe as a workspace package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ pnpm-workspace monorepo (`pnpm-workspace.yaml` → `packages/*`) of independentl
 
 **Build pipelines differ by package — do not assume one shape:**
 
-- `array.utils`, `find-js`, `abonnement-js` — webpack + ts-loader (`build:wp`), UMD output with `libraryTarget: 'umd'`, entry `src/index.ts`, output to `dist/index.js`. The shared `webpack.build.js` at the root provides the rules; each package's `webpack.config.js` extends it with `entry`/`output`.
+- `array.utils`, `find-js`, `abonnement-js`, `maybe` — webpack + ts-loader (`build:wp`), UMD output with `libraryTarget: 'umd'`. The shared `webpack.build.js` at the root provides the rules; each package's `webpack.config.js` extends it with `entry`/`output`. Entry is `src/index.ts` → `dist/index.js` for the first three; `maybe` is the outlier — single-file `src/maybe.ts` → `dist/maybe.js` (filename preserved for the published 2.x contract and the script-tag consumer in `apps/web-js`).
 - `immer-reduxer` — `tsc` only (no webpack bundle), declarations emitted to `dist/`. `peerDependencies` cover `immer`, `redux`, `react-redux`.
 - `git-prompt` — TypeScript (CommonJS). Built with `@vercel/ncc` into three CLI binaries (`git-prompt-co`, `git-prompt-commit`, `git-prompt-retry`) exposed via `bin` in its `package.json`. ncc auto-discovers `tsconfig.json` in the package directory (not `tsconfig.pkg.json` like the other packages); `declaration: false` keeps the bundles from emitting stray `.d.ts` files. The `ts` script runs real `tsc --noEmit`.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This libs are using [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/wor
 - [find-js](./packages/find-js/README.md)
 - [abonnement-js](./packages/abonnement-js/README.md)
 - [array.utils](./packages/array.utils/README.md)
+- [maybe](./packages/maybe/README.md)
 - [git-prompt](./packages/git-prompt/README.md)
 
 [//]: <> (package-list-placeholder-do-not-remove)

--- a/apps/web-cs/package.json
+++ b/apps/web-cs/package.json
@@ -16,7 +16,7 @@
     "@hansogj/abonnement-js": "workspace:*",
     "@hansogj/array.utils": "workspace:*",
     "@hansogj/find-js": "workspace:*",
-    "@hansogj/maybe": "2.7.0",
+    "@hansogj/maybe": "workspace:*",
     "http-server": "14.1.1"
   }
 }

--- a/apps/web-js/package.json
+++ b/apps/web-js/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "pnpm run clean && mkdir dist && cp -rL ../../node_modules/@hansogj node_modules/shared dist && cp index.html style.css src/ dist/. -R",
+    "build": "pnpm run clean && mkdir dist && cp -rL node_modules/@hansogj node_modules/shared dist && cp index.html style.css src/ dist/. -R",
     "start": "pnpm exec http-server -p 2112 dist",
     "test": "echo \"No test specified - all good\"; exit 0"
   },
@@ -14,7 +14,7 @@
     "@hansogj/abonnement-js": "workspace:*",
     "@hansogj/array.utils": "workspace:*",
     "@hansogj/find-js": "workspace:*",
-    "@hansogj/maybe": "2.7.0",
+    "@hansogj/maybe": "workspace:*",
     "http-server": "14.1.1"
   }
 }

--- a/apps/web-ts/package.json
+++ b/apps/web-ts/package.json
@@ -16,7 +16,7 @@
     "@hansogj/abonnement-js": "workspace:*",
     "@hansogj/array.utils": "workspace:*",
     "@hansogj/find-js": "workspace:*",
-    "@hansogj/maybe": "2.7.0",
+    "@hansogj/maybe": "workspace:*",
     "http-server": "14.1.1"
   },
   "devDependencies": {

--- a/harness/shared/scripts/build-deps.js
+++ b/harness/shared/scripts/build-deps.js
@@ -2,8 +2,7 @@
 /*
  * Single source of truth for the dependency/version map used by the harness apps.
  *
- * Workspace packages: read version from `packages/<pkg>/package.json`.
- * External packages (e.g. @hansogj/maybe): read from the installed `node_modules/<pkg>/package.json`.
+ * All entries are workspace packages: read version from `packages/<pkg>/package.json`.
  *
  * Output: harness/shared/src/deps.json — consumed by shared/src/index.js (the `versions` field)
  * and by shared/webpack.common.config.js (HtmlWebpackPlugin templateParameters).
@@ -18,9 +17,8 @@ const workspacePackages = [
   '@hansogj/abonnement-js',
   '@hansogj/array.utils',
   '@hansogj/find-js',
+  '@hansogj/maybe',
 ];
-
-const externalPackages = ['@hansogj/maybe'];
 
 const readVersion = (pkgJsonPath, pkgName) => {
   if (!fs.existsSync(pkgJsonPath)) {
@@ -36,10 +34,6 @@ const deps = {};
 for (const name of workspacePackages) {
   const dir = name.replace(/^@hansogj\//, '');
   deps[name] = readVersion(path.join(repoRoot, 'packages', dir, 'package.json'), name);
-}
-
-for (const name of externalPackages) {
-  deps[name] = readVersion(path.join(repoRoot, 'node_modules', name, 'package.json'), name);
 }
 
 const outPath = path.resolve(__dirname, '..', 'src', 'deps.json');

--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
     "webpack-cli": "7.0.3",
     "webpack-dev-server": "5.2.5"
   },
-  "dependencies": {
-    "@hansogj/maybe": "2.7.0"
-  },
   "pnpm": {
     "overrides": {
       "fast-uri@<3.1.2": ">=3.1.2",

--- a/packages/maybe/LICENSE
+++ b/packages/maybe/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Hans Ole Gjerdrum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/maybe/README.md
+++ b/packages/maybe/README.md
@@ -1,0 +1,58 @@
+# maybe
+
+[![npm version](https://img.shields.io/npm/v/@hansogj/maybe)](https://www.npmjs.com/package/@hansogj/maybe)
+[![known vulnerabilities](https://snyk.io/test/npm/@hansogj/maybe/badge.svg)](https://snyk.io/test/npm/@hansogj/maybe)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@hansogj/maybe)](https://bundlephobia.com/package/@hansogj/maybe)
+
+A lightweight stream-like maybe/orElse lib for optional values. `maybe(val).valueOr(other)` grant you no unexpected undefined and hence allows you to write you TS-code in a more fluid way, skipping some of those if-else nestings.
+
+_Maybe_ also provides some useful filters and chaining into object structures ie
+
+## Some examples
+
+```TS
+  const myObject = {
+        prop: 1,
+        complex: {
+            sub: 'ABC',
+            list: [1, 2, 3],
+            subComplex: { type: 'noType', other: 21, },
+        },
+    };
+
+maybe(myObject).valueOr((undefined as unknown) as typeof myObject); // => myObject
+maybe(undefined as any).valueOr(myObject); // => myObject
+maybe(myObject).mapTo('prop').valueOr(0); // => 1
+maybe(myObject)
+    .mapTo('complex')
+    .map((it) => ((it.sub = 'DEF'), it))
+    .mapTo('sub')
+    .valueOr('null'); // => 'DEF'
+maybe(myObject)
+    .mapTo('complex')
+    .mapTo('list')
+    .map((it) => it.reduce((cur: number, next: number) => (cur += next), 0))
+    .valueOr(0); // => 6
+maybe(myObject)
+    .mapTo('complex')
+    .mapTo('subComplex')
+    .mapTo('other')
+    .nothingIf((it) => it === 21)
+    .valueOr(0); // => 0
+
+```
+
+## Versioning and publishing
+
+We strive to use a [semantic version](https://semver.org/) regime on this lib. From a clean git status do
+
+```bash
+> npm version [ major | minor | patch | premajor | preminor | prepatch | prerelease ]
+> git push && git push --follow-tags
+```
+
+and then publish a new version
+
+```bash
+npm publish
+```

--- a/packages/maybe/package.json
+++ b/packages/maybe/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@hansogj/maybe",
+  "version": "2.7.0",
+  "description": "Maybe monad — safe handling of optional/nullable values",
+  "main": "./dist/maybe.js",
+  "module": "./dist/maybe.js",
+  "types": "./dist/maybe.d.ts",
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "maybe",
+    "monad",
+    "optional",
+    "nullable",
+    "typescript"
+  ],
+  "scripts": {
+    "test": "echo \"see root jest\" && exit 0",
+    "build": "rm -rf dist/* && pnpm run build:wp",
+    "build:ts": "tsc -p tsconfig.pkg.json",
+    "build:wp": "webpack --mode=production --config=webpack.config.js",
+    "clean": "rm -rf dist node_modules coverage *.tgz",
+    "prepack": "pnpm run build",
+    "ts": "tsc --noEmit -p tsconfig.pkg.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hansogj/utils-ws.git"
+  },
+  "author": "Hans Ole Gjerdrum (hansogj@gmail.com)",
+  "contributors": [
+    {
+      "name": "Hans Ole Gjerdrum",
+      "email": "hansogj@gmail.com"
+    },
+    {
+      "name": "Øyvind Kjeldstad Grimnes (Oyvindkg)"
+    }
+  ],
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/hansogj/utils-ws/issues"
+  },
+  "homepage": "https://github.com/hansogj/utils-ws#readme"
+}

--- a/packages/maybe/src/maybe.spec.ts
+++ b/packages/maybe/src/maybe.spec.ts
@@ -1,0 +1,317 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import maybe, { Maybe } from './maybe';
+
+describe('maybe', () => {
+  it('returns something for values', () => expect(maybe(0).isSomething()).toBe(true));
+
+  it('returns nothing for undefined', () => expect(maybe(undefined).isNothing()).toBe(true));
+  it('returns nothing for null', () => expect(maybe(null).isNothing()).toBe(true));
+});
+
+describe('Maybe', () => {
+  describe('static member', () => {
+    describe('just', () => {
+      it('returns something', () => expect(Maybe.just(1).isSomething()).toEqual(true));
+    });
+
+    describe('nothing', () => {
+      it('returns nothing', () => expect(Maybe.nothing().isNothing()).toEqual(true));
+    });
+
+    describe('isNothing', () => {
+      it('returns true for null', () => expect(Maybe.isNothing(null)).toEqual(true));
+      it('returns true for undefined', () => expect(Maybe.isNothing(undefined)).toEqual(true));
+
+      it('returns false for empty objects', () => expect(Maybe.isNothing({})).toEqual(false));
+      it('returns false for empty arrays', () => expect(Maybe.isNothing([])).toEqual(false));
+      it('returns false for empty strings', () => expect(Maybe.isNothing('')).toEqual(false));
+      it('returns false for 0', () => expect(Maybe.isNothing(0)).toEqual(false));
+      it('returns false for values', () => expect(Maybe.isNothing('a value')).toEqual(false));
+    });
+
+    describe('isSomething', () => {
+      it('returns true for empty objects', () => expect(Maybe.isSomething({})).toEqual(true));
+      it('returns true for empty arrays', () => expect(Maybe.isSomething([])).toEqual(true));
+      it('returns true for empty strings', () => expect(Maybe.isSomething('')).toEqual(true));
+      it('returns true for 0', () => expect(Maybe.isSomething(0)).toEqual(true));
+      it('returns true for values', () => expect(Maybe.isSomething('a value')).toEqual(true));
+
+      it('returns false for null', () => expect(Maybe.isSomething(null)).toEqual(false));
+      it('returns false for undefined', () => expect(Maybe.isSomething(undefined)).toEqual(false));
+    });
+  });
+
+  describe('valueOr', () => {
+    it('returns content if something', () => expect(maybe(1).valueOr(2)).toEqual(1));
+    it('returns default if nothing', () => expect(maybe(undefined).valueOr(2 as any)).toEqual(2));
+  });
+
+  describe('valueOrExecute', () => {
+    it('returns content if something', () => expect(maybe(1).valueOrExecute(() => 2)).toEqual(1));
+    it('returns value from callback if nothing', () =>
+      expect(maybe(undefined).valueOrExecute(() => 2 as any)).toEqual(2));
+  });
+
+  describe('valueOrThrow', () => {
+    it('returns content if something', () => expect(maybe(1).valueOrThrow()).toEqual(1));
+    it('throws error if nothing', () => expect(() => maybe(undefined).valueOrThrow()).toThrow());
+  });
+
+  describe('isSomething', () => {
+    it('returns true if something', () => expect(maybe(2).isSomething()).toBe(true));
+    it('returns false if nothing', () => expect(maybe(undefined).isSomething()).toBe(false));
+  });
+
+  describe('isNothing', () => {
+    it('returns true if nothing', () => expect(maybe(undefined).isNothing()).toBe(true));
+    it('returns false if something', () => expect(maybe(2).isNothing()).toBe(false));
+  });
+
+  describe('map', () => {
+    it('returns the mapped value if something', () =>
+      expect(
+        maybe(0)
+          .map((i) => i + 1)
+          .valueOrThrow(),
+      ).toEqual(1));
+
+    it('returns nothing if nothing', () =>
+      expect(
+        maybe(null)
+          .map((i: any) => i + 1)
+          .isNothing(),
+      ).toBe(true));
+
+    it('returns nothing if mapped value is nothing', () =>
+      expect(
+        maybe(1)
+          .map(() => null)
+          .isNothing(),
+      ).toBe(true));
+  });
+
+  describe('tap', () => {
+    let spy: jest.Mock;
+    let result: any;
+    const value = 'My Value';
+    beforeEach(() => {
+      spy = jest.fn();
+      result = maybe(value).tap(spy).valueOr('Other');
+    });
+    it('has called callback', () => expect(spy).toHaveBeenCalledTimes(1));
+
+    it('has called callback with current value', () => expect(spy).toHaveBeenCalledWith(value));
+
+    it('has left value unchanged', () => expect(result).toEqual(value));
+  });
+
+  describe('mapTo', () => {
+    it('returns property if value and property is something', () =>
+      expect(maybe({ prop: 2 }).mapTo('prop').valueOrThrow()).toEqual(2));
+    it('returns nothing if value is nothing', () =>
+      expect(
+        maybe<{ prop: number }>(null as any)
+          .mapTo('prop')
+          .isNothing(),
+      ).toEqual(true));
+    it('returns nothing if property is nothing', () =>
+      expect(maybe({ prop: null }).mapTo('prop').isNothing()).toEqual(true));
+  });
+
+  describe('pick', () => {
+    it('returns property if value and property is something', () =>
+      expect(maybe({ prop: 2 }).pick('prop').valueOrThrow()).toEqual({ prop: 2 }));
+
+    it('returns property if empty if value is nothing', () =>
+      expect(maybe({ prop: undefined }).pick('prop').valueOrThrow()).toEqual({}));
+
+    it('returns every properties present', () =>
+      expect(
+        maybe({ prop1: 1, prop2: 2, prop3: null }).pick('prop1', 'prop2', 'prop3').valueOrThrow(),
+      ).toEqual({
+        prop1: 1,
+        prop2: 2,
+      }));
+  });
+
+  describe('ifNothing', () => {
+    let spy: jest.SpyInstance;
+    beforeEach(() => (spy = jest.fn().mockReturnValue(100)));
+
+    it('should not evoke callback', () => {
+      expect(
+        maybe(1)
+          .ifNothing(spy as any)
+          .valueOr(2),
+      ).toEqual(1);
+      expect(spy).not.toHaveBeenCalled();
+    });
+    it('should evoke callback', () => {
+      expect(
+        maybe(undefined)
+          .ifNothing(spy as any)
+          .valueOr(1),
+      ).toEqual(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stringify', () => {
+    it.each([
+      ['', ''],
+      [1, '1'],
+      [true, 'true'],
+      [[], '[]'],
+      [{}, '{}'],
+      [{ a: [] }, '{a:[]}'],
+      [{ a: { b: { c: [{}, 'a', 1, []] } } }, '{a:{b:{c:[{},a,1,[]]}}}'],
+    ])("should stringify value %j to '%s'", (value: any, stringifiedValue: string) => {
+      expect(maybe(value).stringify().valueOrThrow()).toEqual(stringifiedValue);
+    });
+
+    it('should be nothing of value is undefined', () =>
+      expect(maybe(undefined).stringify().isNothing()).toBeTruthy());
+  });
+
+  describe('flatMap', () => {
+    it('returns the mapped value if something', () =>
+      expect(
+        maybe(0)
+          .flatMap((i) => maybe(i + 1))
+          .valueOrThrow(),
+      ).toEqual(1));
+
+    it('returns nothing if nothing', () =>
+      expect(
+        maybe(null)
+          .flatMap((i: any) => maybe(i + 1))
+          .isNothing(),
+      ).toBe(true));
+
+    it('returns nothing if mapped value is nothing', () =>
+      expect(
+        maybe(1)
+          .flatMap(() => maybe(null))
+          .isNothing(),
+      ).toBe(true));
+  });
+
+  describe('isNothing', () => {
+    it('returns true for null', () => expect(maybe(null).isNothing()).toEqual(true));
+    it('returns true for undefined', () => expect(maybe(undefined).isNothing()).toEqual(true));
+
+    it('returns false for empty objects', () => expect(maybe({}).isNothing()).toEqual(false));
+    it('returns false for empty arrays', () => expect(maybe([]).isNothing()).toEqual(false));
+    it('returns false for empty strings', () => expect(maybe('').isNothing()).toEqual(false));
+    it('returns false for 0', () => expect(maybe(0).isNothing()).toEqual(false));
+    it('returns false for values', () => expect(maybe('a value').isNothing()).toEqual(false));
+  });
+
+  describe('isSomething', () => {
+    it('returns true for empty objects', () => expect(maybe({}).isSomething()).toBe(true));
+    it('returns true for empty arrays', () => expect(maybe([]).isSomething()).toBe(true));
+    it('returns true for empty strings', () => expect(maybe('').isSomething()).toBe(true));
+    it('returns true for 0', () => expect(maybe(0).isSomething()).toBe(true));
+    it('returns true for values', () => expect(maybe('a value').isSomething()).toBe(true));
+
+    it('returns false for null', () => expect(maybe(null).isSomething()).toBe(false));
+    it('returns false for undefined', () => expect(maybe(undefined).isSomething()).toBe(false));
+  });
+
+  describe('nothingUnless', () => {
+    it('returns something if true', () =>
+      expect(
+        maybe(1)
+          .nothingUnless(() => true)
+          .isNothing(),
+      ).toBe(false));
+
+    it('returns nothing if false', () =>
+      expect(
+        maybe(1)
+          .nothingUnless(() => false)
+          .isNothing(),
+      ).toBe(true));
+  });
+
+  describe('nothingIf', () => {
+    it('returns nothing if true', () =>
+      expect(
+        maybe(1)
+          .nothingIf(() => true)
+          .isNothing(),
+      ).toBe(true));
+
+    it('returns something if false', () =>
+      expect(
+        maybe(1)
+          .nothingIf(() => false)
+          .isNothing(),
+      ).toBe(false));
+  });
+
+  describe('ifTrue', () => {
+    it.each([
+      [true, true],
+      [1, true],
+      [{}, true],
+      [[], true],
+      [false, false],
+      [0, false],
+      ['', false],
+    ])("of value %j should be '%s'", (value: any, expected: boolean) => {
+      expect(maybe(value).ifTrue().isSomething()).toBe(expected);
+    });
+  });
+
+  describe('ifFalse', () => {
+    it.each([
+      [true, false],
+      [1, false],
+      [{}, false],
+      [[], false],
+      [false, true],
+      [0, true],
+      ['', true],
+    ])("of value %j should be '%s'", (value: any, expected: boolean) => {
+      expect(maybe(value).ifFalse().isSomething()).toBe(expected);
+    });
+  });
+
+  describe('or', () => {
+    it('returns original if something', () =>
+      expect(maybe(1).or(maybe(2)).valueOrThrow()).toEqual(1));
+
+    it('returns other if nothing', () =>
+      expect(
+        maybe(null)
+          .or(maybe(2) as any)
+          .valueOrThrow(),
+      ).toEqual(2));
+  });
+
+  describe('orJust', () => {
+    it('returns original if something', () => expect(maybe(1).orJust(2).valueOrThrow()).toEqual(1));
+
+    it('returns other if nothing', () =>
+      expect(
+        maybe(null)
+          .orJust(2 as any)
+          .valueOrThrow(),
+      ).toEqual(2));
+  });
+
+  describe('zip', () => {
+    it('returns merged values if both values are something', () =>
+      expect(maybe(1).zip(maybe(2)).valueOrThrow()).toEqual([1, 2]));
+
+    it('returns nothing if both values are nothing', () =>
+      expect(maybe(null).zip(maybe(null)).isNothing()).toEqual(true));
+
+    it('returns nothing if first value is nothing', () =>
+      expect(maybe(null).zip(maybe(2)).isNothing()).toEqual(true));
+
+    it('returns nothing if second value is nothing', () =>
+      expect(maybe(1).zip(maybe(null)).isNothing()).toEqual(true));
+  });
+});

--- a/packages/maybe/src/maybe.ts
+++ b/packages/maybe/src/maybe.ts
@@ -1,0 +1,124 @@
+export type Optional<T> = T | undefined;
+
+export class Maybe<Value> {
+  private readonly wrappedValue: Optional<Value>;
+
+  constructor(wrappedValue: Optional<Value>) {
+    this.wrappedValue = wrappedValue;
+  }
+
+  // Extracting the value
+  valueOr = <T>(defaultValue: T): Value | T =>
+    Maybe.isSomething(this.wrappedValue) ? this.wrappedValue : defaultValue;
+
+  valueOrThrow = (
+    error: Error = new TypeError('Wrapped value is undefined or null'),
+  ): Value | never =>
+    this.valueOrExecute(() => {
+      throw error;
+    });
+
+  valueOrExecute = <T>(closure: () => T | Value): T | Value =>
+    Maybe.isSomething(this.wrappedValue) ? this.wrappedValue : closure();
+
+  // Existence checking
+  isSomething = (): boolean => !this.isNothing();
+
+  isNothing = (): boolean => this.wrappedValue === undefined || this.wrappedValue === null;
+
+  // Mapping
+  map = <Output>(mapper: (value: Value) => Optional<Output>): Maybe<Output> =>
+    // eslint-disable-next-line
+    // @ts-ignore
+    this.isNothing() ? Maybe.nothing() : new Maybe(mapper(this.wrappedValue));
+
+  flatMap = <Output>(mapper: (value: Value) => Maybe<Output>): Maybe<Output> =>
+    this.map(mapper).map((it) => it.wrappedValue);
+
+  // runs callback without changing value
+  tap = (callback: (val: Value) => unknown) => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    callback(this.wrappedValue);
+    return this;
+  };
+
+  // Conditional callbacks
+  ifNothing = (callback: () => void): Maybe<Value> => {
+    if (this.isNothing()) {
+      callback();
+    }
+    return this;
+  };
+
+  ifSomething = (callback: (_: Value) => void): Maybe<Value> =>
+    this.map((value) => {
+      callback(value);
+      return value;
+    });
+
+  // Filtering
+  nothingUnless = (filter: (_: Value) => boolean): Maybe<Value> =>
+    this.map((value) => (filter(value) ? value : undefined));
+
+  nothingIf = (filter: (_: Value) => boolean): Maybe<Value> =>
+    this.nothingUnless((it) => !filter(it));
+
+  ifTrue = () => this.nothingUnless((value: Value) => Boolean(value));
+
+  ifFalse = () => this.nothingUnless((value: Value) => !Boolean(value));
+
+  // Utilities
+  or = (other: Maybe<Value>): Maybe<Value> => (this.isNothing() ? other : this);
+
+  orJust = (other: Value): Maybe<Value> => (this.isNothing() ? Maybe.just(other) : this);
+
+  zip<OtherValue>(other: Maybe<OtherValue>): Maybe<[Value, OtherValue]> {
+    return this.map(
+      (it) => other.map((t: OtherValue): [Value, OtherValue] => [it, t]).wrappedValue,
+    );
+  }
+
+  mapTo = <Key extends keyof Value>(key: Key): Maybe<Value[Key]> => this.map((value) => value[key]);
+
+  pick = <Key extends keyof Value>(...keys: Key[]): Maybe<Record<Key, Value[Key]>> =>
+    new Maybe(
+      keys.reduce(
+        (curr, key) =>
+          this.mapTo(key)
+            .map((it) => ({
+              ...curr,
+              [key]: it,
+            }))
+            .valueOr(curr),
+        {} as Record<Key, Value[Key]>,
+      ),
+    );
+
+  stringify = (): Maybe<string> => this.map((value) => JSON.stringify(value).replace(/\"/g, ''));
+
+  // Static members
+  static just<Value>(value: Value): Maybe<Value> {
+    return new Maybe<Value>(value);
+  }
+
+  static nothing<Value>(): Maybe<Value> {
+    return new Maybe<Value>(undefined);
+  }
+
+  static isSomething<Value>(value: Optional<Value>): value is Value {
+    return !this.isNothing(value);
+  }
+
+  static isNothing<Value>(value: Optional<Value>): value is undefined {
+    return new Maybe(value).isNothing();
+  }
+}
+
+export default function maybe<Value>(value: Optional<Value>): Maybe<Value> {
+  if (Maybe.isNothing(value)) {
+    return Maybe.nothing();
+  }
+
+  return Maybe.just(value);
+}

--- a/packages/maybe/tsconfig.pkg.json
+++ b/packages/maybe/tsconfig.pkg.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.pkg.base.json",
+    "compilerOptions": {
+        "outDir": "./dist/"
+    },
+    "files": [
+        "src/maybe.ts"
+    ]
+}

--- a/packages/maybe/webpack.config.js
+++ b/packages/maybe/webpack.config.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const webpack = require('../../webpack.build.js');
+const config = webpack();
+
+module.exports = () => ({
+    ...config,
+    entry: './src/maybe.ts',
+    output: {
+        ...config.output,
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'maybe.js',
+        library: 'maybe',
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,10 +14,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@hansogj/maybe':
-        specifier: 2.7.0
-        version: 2.7.0
     devDependencies:
       '@babel/core':
         specifier: 7.29.7
@@ -152,8 +148,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/find-js
       '@hansogj/maybe':
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: workspace:*
+        version: link:../../packages/maybe
       http-server:
         specifier: 14.1.1
         version: 14.1.1
@@ -173,8 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/find-js
       '@hansogj/maybe':
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: workspace:*
+        version: link:../../packages/maybe
       http-server:
         specifier: 14.1.1
         version: 14.1.1
@@ -194,8 +190,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/find-js
       '@hansogj/maybe':
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: workspace:*
+        version: link:../../packages/maybe
       http-server:
         specifier: 14.1.1
         version: 14.1.1
@@ -253,6 +249,8 @@ importers:
       redux:
         specifier: ^5.0.1
         version: 5.0.1
+
+  packages/maybe: {}
 
 packages:
 
@@ -1065,10 +1063,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@hansogj/maybe@2.7.0':
-    resolution: {integrity: sha512-EoYaefYZ6t5Wo2ttolRZ4QML2IWdNasYFBG0zf56i/Kig72hdjY8APiFn7SAYw95qSZTa53kJde4lo1kkCPbaQ==}
-    engines: {node: ^ 21 || ^ 22 || ^24 || ^ 25}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -6295,8 +6289,6 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.1': {}
-
-  '@hansogj/maybe@2.7.0': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
## Summary

Folds the standalone `hansogj/maybe` repo into this monorepo, matching the pattern of the other published packages. After this lands, all four published `@hansogj/*` libraries (`abonnement-js`, `array.utils`, `find-js`, `maybe`) live next to the integration harness that verifies them.

## Changes

- **`packages/maybe/`** — new workspace pkg. Source copied from `hansogj/maybe`. Test file renamed `maybe.test.ts → maybe.spec.ts` so root jest's `testMatch` picks it up. Build config adopts the existing pattern: `webpack.config.js` extends root `webpack.build.js`; `tsconfig.pkg.json` extends `tsconfig.pkg.base.json`. Output filename preserved as `dist/maybe.js` for the published 2.x contract and the script-tag consumer in `apps/web-js`.
- **One source change**: `tap()` on `Maybe<Value>` needed an `@ts-ignore` for the same reason `map()` already had one — utils-ws's tsconfig has `strict: true`, the original maybe repo did not. Behavior unchanged.
- **`apps/web-{cs,ts,js}`** now consume `@hansogj/maybe` via `workspace:*` instead of the npm registry. Root no longer carries it as a dependency.
- **`harness/shared/scripts/build-deps.js`** drops the `externalPackages` branch entirely — every entry is now a workspace package read from `packages/<pkg>/package.json`.
- **`apps/web-js` build script**: `../../node_modules/@hansogj` → `node_modules/@hansogj`. The old path relied on root hoisting that happened because maybe was a root dep; with no root `@hansogj/*` deps left, the workspace-scoped per-app `node_modules` is the correct source.
- **README** adds maybe to the active Workspaces list.
- **CLAUDE.md** notes maybe as the outlier in the webpack-based group (single-file source, non-standard dist filename).

## Test plan

- [x] `pnpm i --frozen-lockfile` — clean install, `prepare` regenerates `deps.json` with maybe from `packages/`
- [x] `pnpm run build` — all 6 workspace packages build
- [x] `pnpm test` — 308 tests pass (up from 214, +94 from maybe)
- [x] `pnpm run harness:test` — web-cs (12/12) + web-ts (19/19) + web-js (no tests)
- [x] `pnpm run pre-commit` — full pipeline green
- [x] CI green across the matrix

## Follow-up (after merge)

Same archive flow as `package-test-utils`:

1. Add archive notice to `hansogj/maybe/README.md` pointing to `utils-ws`
2. `gh api -X PATCH repos/hansogj/maybe -F archived=true`
3. Optionally delete local clone at `/git/hansogj/develop/maybe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)