### PR TITLE
feat(find-js): modernize packaging — dual ESM/CJS exports, type:module

### DIFF
--- a/apps/web-js/index.html
+++ b/apps/web-js/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <title>[TestUtil: Dinosaur JS]</title>
-        <script src="@hansogj/find-js/dist/index.js"></script>
+        <script src="@hansogj/find-js/dist/index.umd.js"></script>
         <script src="@hansogj/array.utils/dist/index.umd.js"></script>
         <script src="@hansogj/array.utils/dist/defined/index.umd.js"></script>
         <script src="@hansogj/maybe/dist/maybe.js"></script>

--- a/packages/find-js/package.json
+++ b/packages/find-js/package.json
@@ -1,13 +1,29 @@
 {
   "name": "@hansogj/find-js",
   "version": "6.7.5",
-  "description": "Returning an iterable array of the result of  querySelectorAll from root to selector ",
-  "main": "./dist/index.js",
+  "description": "Returning an iterable array of the result of querySelectorAll from root to selector",
+  "type": "module",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "unpkg": "./dist/index.umd.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.umd.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "keywords": [
     "find",
     "select",
@@ -16,18 +32,16 @@
     "array"
   ],
   "author": "Hans Ole Gjerdrum (hansogj@gmail.com)",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "license": "MIT",
-  "dependencies": {
-    "array-from": "^2.1.1"
-  },
   "scripts": {
-    "build": "rm -rf dist/* && pnpm run build:wp",
-    "build:ts": "tsc -p tsconfig.pkg.json",
-    "build:wp": "webpack --mode=production --config=webpack.config.js",
+    "build": "rm -rf dist && pnpm run build:ts && pnpm run build:esm && pnpm run build:umd",
+    "build:ts": "tsc -p tsconfig.pkg.json --emitDeclarationOnly --declaration",
+    "build:esm": "vite build",
+    "build:umd": "webpack --mode=production --config=webpack.config.cjs",
     "clean": "rm -rf dist node_modules coverage *.tgz",
     "prepack": "pnpm run build",
     "ts": "tsc --noEmit -p tsconfig.pkg.json"

--- a/packages/find-js/vite.config.ts
+++ b/packages/find-js/vite.config.ts
@@ -13,5 +13,16 @@ export default defineConfig({
       formats: ['es', 'cjs'],
       fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
     },
+    rollupOptions: {
+      output: {
+        // Force `exports.default = X` in CJS even for default-only modules.
+        // Without this, rollup/vite "helpfully" unwraps to `module.exports = X`
+        // for default-only modules — but consumers like web-cs/web-ts do
+        // `require('@hansogj/find-js').default` and would receive undefined.
+        // Modules with named exports get `exports = { default, ... }` naturally;
+        // this just makes the default-only case behave the same way.
+        exports: 'named',
+      },
+    },
   },
 });

--- a/packages/find-js/vite.config.ts
+++ b/packages/find-js/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+
+// Single-entry library. ESM (.js) + CJS (.cjs). Types come from tsc (build:ts).
+// UMD (`dist/index.umd.js`) comes from webpack (build:umd) so the script-tag
+// consumer in apps/web-js still works.
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    minify: false,
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+  },
+});

--- a/packages/find-js/webpack.config.cjs
+++ b/packages/find-js/webpack.config.cjs
@@ -1,13 +1,16 @@
+// UMD output for the script-tag consumer in apps/web-js.
+// ESM + CJS outputs are produced by vite (see vite.config.ts).
 const path = require('path');
 const webpack = require('../../webpack.build.js');
 const config = webpack();
 
 module.exports = () => ({
     ...config,
+    entry: './src/index.ts',
     output: {
         ...config.output,
         path: path.resolve(__dirname, 'dist'),
-        filename: 'index.js',
+        filename: 'index.umd.js',
         library: 'find',
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,11 +228,7 @@ importers:
 
   packages/array.utils: {}
 
-  packages/find-js:
-    dependencies:
-      array-from:
-        specifier: ^2.1.1
-        version: 2.1.1
+  packages/find-js: {}
 
   packages/git-prompt:
     dependencies:
@@ -2175,9 +2171,6 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-
-  array-from@2.1.1:
-    resolution: {integrity: sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==}
 
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
@@ -7822,8 +7815,6 @@ snapshots:
       is-array-buffer: 3.0.5
 
   array-flatten@1.1.1: {}
-
-  array-from@2.1.1: {}
 
   array-includes@3.1.9:
     dependencies:


### PR DESCRIPTION
## Summary

Second package on the modern template (after array.utils in #36). Follows the same three-stage build: `tsc` for types, `vite` for ESM/CJS, `webpack` for a single UMD bundle that backs the script-tag consumer in `apps/web-js`.

Simpler than array.utils — single entry, single default export, no polyfill side-effects, so no `treeshake: false` or `optimization.sideEffects: false` needed and `sideEffects: false` in package.json gives downstream consumers maximum tree-shake headroom.

The UMD keeps `library: 'find'` so `window.find = { default: <fn>, __esModule: true }`; the existing `window.find.default` pattern in `apps/web-js` keeps working unchanged.

## Consumer updates

- `apps/web-js/index.html`: `dist/index.js` → `dist/index.umd.js`

ESM/CJS consumers (`apps/web-{cs,ts}`) don't need a change — they resolve through the new `exports.{import,require}` conditions to `dist/index.{js,cjs}`, both of which expose `default` correctly (no `__esModule`-inside-IIFE interop trap since Vite emits real ESM).

## Test plan

- [x] `pnpm run pre-commit` green (308 + 31)
- [x] `pnpm run harness:e2e` — 3 passed
- [x] Manual: docker compose stack renders correctly in browser
- [ ] CI green

## Follow-ups

Next: `maybe` (similar shape: single-file, default export). Then `abonnement-js` (depends on `array.utils` via `workspace:*`). Then `git-prompt` (CLI — different output shape).