### PR TITLE
feat(maybe): modernize packaging — dual ESM/CJS exports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,14 @@ jobs:
 
             - name: E2E harness apps (Playwright)
               run: pnpm run harness:e2e
+
+            - name: Upload Playwright report on failure
+              if: failure()
+              uses: actions/upload-artifact@v6
+              with:
+                  name: playwright-report-node-${{ matrix.node-version }}
+                  path: |
+                      harness/e2e/playwright-report/
+                      harness/e2e/test-results/
+                  retention-days: 7
+                  if-no-files-found: ignore

--- a/packages/maybe/package.json
+++ b/packages/maybe/package.json
@@ -3,11 +3,26 @@
   "version": "2.7.0",
   "description": "Maybe monad — safe handling of optional/nullable values",
   "main": "./dist/maybe.js",
-  "module": "./dist/maybe.js",
+  "module": "./dist/maybe.mjs",
   "types": "./dist/maybe.d.ts",
+  "unpkg": "./dist/maybe.js",
+  "exports": {
+    ".": {
+      "types": "./dist/maybe.d.ts",
+      "import": "./dist/maybe.mjs",
+      "require": "./dist/maybe.cjs",
+      "default": "./dist/maybe.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "keywords": [
     "maybe",
     "monad",
@@ -17,9 +32,10 @@
   ],
   "scripts": {
     "test": "echo \"see root jest\" && exit 0",
-    "build": "rm -rf dist/* && pnpm run build:wp",
-    "build:ts": "tsc -p tsconfig.pkg.json",
-    "build:wp": "webpack --mode=production --config=webpack.config.js",
+    "build": "rm -rf dist && pnpm run build:ts && pnpm run build:esm && pnpm run build:umd",
+    "build:ts": "tsc -p tsconfig.pkg.json --emitDeclarationOnly --declaration",
+    "build:esm": "vite build",
+    "build:umd": "webpack --mode=production --config=webpack.config.cjs",
     "clean": "rm -rf dist node_modules coverage *.tgz",
     "prepack": "pnpm run build",
     "ts": "tsc --noEmit -p tsconfig.pkg.json"

--- a/packages/maybe/vite.config.ts
+++ b/packages/maybe/vite.config.ts
@@ -17,5 +17,16 @@ export default defineConfig({
       formats: ['es', 'cjs'],
       fileName: (format) => `maybe.${format === 'es' ? 'mjs' : 'cjs'}`,
     },
+    rollupOptions: {
+      output: {
+        // Force `exports.default = X` in CJS even if some future refactor leaves
+        // only a default export. Today maybe has both `Maybe` (named) and `maybe`
+        // (default), so rollup naturally uses the object form — but adding this
+        // explicitly future-proofs against the trap that bit find-js (#37):
+        // default-only modules get unwrapped to `module.exports = X`, breaking
+        // consumers that do `require(...).default`.
+        exports: 'named',
+      },
+    },
   },
 });

--- a/packages/maybe/vite.config.ts
+++ b/packages/maybe/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+
+// Single-entry library. ESM (.mjs) + CJS (.cjs). Types come from tsc (build:ts).
+// UMD `dist/maybe.js` comes from webpack (build:umd) — the existing filename is
+// preserved so the published 2.x script-tag path keeps working unchanged.
+//
+// We do NOT set `"type": "module"` in package.json for this package, precisely
+// so `dist/maybe.js` can remain a UMD bundle (interpretable as both CJS and
+// browser global). Hence the explicit `.mjs` for ESM and `.cjs` for CJS.
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    minify: false,
+    lib: {
+      entry: 'src/maybe.ts',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `maybe.${format === 'es' ? 'mjs' : 'cjs'}`,
+    },
+  },
+});

--- a/packages/maybe/webpack.config.cjs
+++ b/packages/maybe/webpack.config.cjs
@@ -1,3 +1,7 @@
+// UMD output for the script-tag consumer in apps/web-js.
+// Filename `maybe.js` preserved so the published 2.x path keeps working.
+// ESM (`maybe.mjs`) + CJS (`maybe.cjs`) outputs are produced by vite (see
+// vite.config.ts).
 const path = require('path');
 const webpack = require('../../webpack.build.js');
 const config = webpack();


### PR DESCRIPTION
## Summary

Third package on the modern template (after array.utils #36 and find-js #37). Diverges slightly: we do **NOT** set `"type": "module"` here so the published 2.x path `dist/maybe.js` can remain a UMD bundle. External script-tag consumers that hardcode `@hansogj/maybe/dist/maybe.js` keep working unchanged.

## Layout

| File | What | Built by |
|---|---|---|
| `dist/maybe.js` | UMD (filename preserved, `library: 'maybe'`) | webpack |
| `dist/maybe.mjs` | ESM | vite |
| `dist/maybe.cjs` | CJS | vite |
| `dist/maybe.d.ts` | Types | tsc (`--emitDeclarationOnly`) |

## How consumers resolve

- ESM: `exports.import` → `dist/maybe.mjs`
- CJS: `exports.require` → `dist/maybe.cjs`
- script-tag / file-path catchall: `exports.default` → `dist/maybe.js`

Single default export, no polyfills → `sideEffects: false`, no tree-shake or `optimization.sideEffects` tweaks needed. Build is the standard three stages: tsc → vite → webpack.

## Consumer updates

**None required.** `apps/web-js` keeps loading `dist/maybe.js`; web-cs/web-ts keep their unchanged `import`/`require` calls and now hit `dist/maybe.mjs`/`dist/maybe.cjs` via the `exports` map.

## Test plan

- [x] `pnpm run pre-commit` green (308 + 31)
- [x] `pnpm run harness:e2e` — 3 passed
- [ ] CI green

## Follow-ups

After this: `abonnement-js` (only one with an internal `workspace:*` dependency — on `array.utils`). Then `git-prompt` (CLI, different shape).