### PR TITLE
feat(abonnement-js): modernize packaging — dual ESM/CJS exports

### DIFF
--- a/packages/abonnement-js/package.json
+++ b/packages/abonnement-js/package.json
@@ -3,7 +3,26 @@
   "version": "4.7.5",
   "description": "lightweight naive event subscription",
   "main": "./dist/abonnement.js",
+  "module": "./dist/abonnement.mjs",
   "types": "./dist/abonnement.d.ts",
+  "unpkg": "./dist/abonnement.js",
+  "exports": {
+    ".": {
+      "types": "./dist/abonnement.d.ts",
+      "import": "./dist/abonnement.mjs",
+      "require": "./dist/abonnement.cjs",
+      "default": "./dist/abonnement.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
   "keywords": [
     "event",
     "typescript",
@@ -14,10 +33,11 @@
     "@hansogj/array.utils": "workspace:*"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf dist/* && pnpm run build:wp",
-    "build:ts": "tsc -p tsconfig.pkg.json",
-    "build:wp": "webpack --mode=production --config=webpack.config.js",
+    "test": "echo \"see root jest\" && exit 0",
+    "build": "rm -rf dist && pnpm run build:ts && pnpm run build:esm && pnpm run build:umd",
+    "build:ts": "tsc -p tsconfig.pkg.json --emitDeclarationOnly --declaration",
+    "build:esm": "vite build",
+    "build:umd": "webpack --mode=production --config=webpack.config.cjs",
     "clean": "rm -rf dist node_modules coverage *.tgz",
     "prepack": "pnpm run build",
     "ts": "tsc --noEmit -p tsconfig.pkg.json"
@@ -28,11 +48,12 @@
   },
   "author": "Hans Ole Gjerdrum (hansogj@gmail.com)",
   "license": "ISC",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "bugs": {
     "url": "https://github.com/hansogj/utils-ws/issues"
   },
-  "homepage": "https://github.com/hansogj/utils-ws#readme",
-  "files": [
-    "dist"
-  ]
+  "homepage": "https://github.com/hansogj/utils-ws#readme"
 }

--- a/packages/abonnement-js/vite.config.ts
+++ b/packages/abonnement-js/vite.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vite';
+
+// Single-entry library. ESM (.mjs) + CJS (.cjs) for the modern conditions in
+// package.json `exports`; UMD `dist/abonnement.js` comes from webpack
+// (build:umd) — filename preserved so the published 4.x script-tag path keeps
+// working. Like maybe, this package does NOT set `"type": "module"` so the UMD
+// at `dist/abonnement.js` stays interpretable as CJS + browser global.
+//
+// `@hansogj/array.utils` is a workspace dep with its own modern `exports` map;
+// rollup picks `exports.import` → ESM `dist/index.js` automatically.
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    minify: false,
+    lib: {
+      entry: 'src/abonnement.ts',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `abonnement.${format === 'es' ? 'mjs' : 'cjs'}`,
+    },
+    rollupOptions: {
+      // Don't bundle the workspace dep — let the consumer resolve it via
+      // package.json `dependencies` + their own bundler / Node resolution.
+      external: ['@hansogj/array.utils'],
+      output: {
+        // Force `exports.X = …` (with __esModule:true) shape so consumers can
+        // safely do `require('@hansogj/abonnement-js').Abonnement`. Same fix
+        // as #37 — applied preemptively even though this package has named
+        // exports today.
+        exports: 'named',
+      },
+    },
+  },
+});

--- a/packages/abonnement-js/webpack.config.cjs
+++ b/packages/abonnement-js/webpack.config.cjs
@@ -1,3 +1,7 @@
+// UMD output for the (theoretical) script-tag consumer.
+// Filename `abonnement.js` preserved so the published 4.x path keeps working.
+// ESM (`abonnement.mjs`) + CJS (`abonnement.cjs`) outputs come from vite (see
+// vite.config.ts).
 const path = require('path');
 const webpack = require('../../webpack.build.js');
 const config = webpack();


### PR DESCRIPTION
## Summary

Fourth library on the modern template. Follows the maybe shape (#38): preserve the published UMD filename (`dist/abonnement.js`) so external script-tag consumers keep working, and use explicit `.mjs` for ESM + `.cjs` for CJS without setting `"type": "module"`.

## Quirk handled

abonnement-js depends on `@hansogj/array.utils` via `workspace:*` — the only library in the monorepo with an internal cross-package dependency. `vite.config.ts` marks `@hansogj/array.utils` as `external` in `rollupOptions` so the ESM/CJS bundles don't inline it; consumers resolve it via their own dependency/bundler chain, same as before. Webpack UMD still inlines it (default behavior) since the script-tag consumer can't resolve npm deps at runtime.

## Other notes

- Includes the `output.exports: 'named'` fix from #37 preemptively. abonnement-js has only named exports (`Abonnement`, `JoinedAbonnement`, `AlleAbonnementer`) and so naturally avoids the default-only unwrap trap, but explicit is safer.
- Drops the empty `src/index.ts` (never referenced; webpack/vite entry has always been `src/abonnement.ts`).

## Consumer updates

**None.** All three apps resolve via the `exports` map without source changes:
- web-cs: `require('@hansogj/abonnement-js').Abonnement` → `exports.Abonnement`
- web-ts: `import { Abonnement } from '@hansogj/abonnement-js'` → ESM named
- web-js: doesn't load abonnement-js via script tag

## Test plan

- [x] `pnpm run pre-commit` green (308 + 31)
- [x] `pnpm run harness:e2e` — 3 passed
- [ ] CI green

## Follow-up

Last package: `git-prompt` (CLI built with `@vercel/ncc` — different shape, only needs `exports` adjusted for `bin` rather than dual ESM/CJS).