### PR TITLE
docs: README corrections after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ End-to-end verification that the published packages work in three consumption mo
 ```bash
 pnpm run harness:build      # builds shared + all three apps
 pnpm run harness:test       # jest in web-cs + web-ts (web-js has no tests)
+pnpm run harness:e2e        # Playwright headless against all three apps (CI runs this; not in pre-commit)
 pnpm web-ts serve           # http://localhost:3113
 pnpm web-cs serve           # http://localhost:4114
 pnpm web-js start           # http://localhost:2112 (needs `pnpm web-js build` first)
@@ -75,7 +76,9 @@ docker compose -f harness/docker/docker-compose.yml down && \
   docker compose -f harness/docker/docker-compose.yml up
 ```
 
-Versions shown in the apps come from a single source of truth: `harness/shared/scripts/build-deps.js` reads `packages/<pkg>/package.json` (workspace packages) and `node_modules/@hansogj/maybe/package.json` (external) and writes `harness/shared/src/deps.json`. The generator runs automatically on `pnpm i` via the `prepare` script.
+Versions shown in the apps come from a single source of truth: `harness/shared/scripts/build-deps.js` reads `packages/<pkg>/package.json` for every workspace package and writes `harness/shared/src/deps.json`. The generator runs automatically on `pnpm i` via the `prepare` script.
+
+The Playwright suite lives in `harness/e2e/` — it boots http-servers for the three built apps via `playwright.config.ts`'s `webServer` block and asserts on the rendered DOM (heading, version list, success/error `<pre>` counts). Catches build-time regressions that the in-process jest tests miss — e.g. the tree-shaking-vs-polyfill issue that surfaced during the array.utils modernization.
 
 ## Versioning
 

--- a/packages/abonnement-js/README.md
+++ b/packages/abonnement-js/README.md
@@ -6,27 +6,21 @@
 
 lightweight, naive, event susbscription
 
-## Simple excample
+## Simple example
 
 ```typescript
-import {
-  Abonnement,
-  JoinedAbonnement,
-  AlleAbonnementer,
-} from "../src/abonnement";
+import { Abonnement, JoinedAbonnement, AlleAbonnementer } from '@hansogj/abonnement-js';
 
-
-let stringAbonnement: Abonnement<String> =  new Abonnement<String>("start value")
-stringAbonnement.abonner(e => console.log("current value is " + e);
-stringAbonnement.varsle("updated value")
-
+const stringAbonnement: Abonnement<string> = new Abonnement<string>('start value');
+stringAbonnement.abonner((e) => console.log('current value is ' + e));
+stringAbonnement.varsle('updated value');
 ```
 
-Inspect the [test](src/abonnement.spec.ts)-file for usage
+Inspect the [test](src/abonnement.spec.ts) file for more usage patterns.
 
 ## Develop
 
-`npm ci & npm build` to build this pack
+This package is part of the [`@hansogj/utils-ws`](https://github.com/hansogj/utils-ws) monorepo — see the root README for build, test and release flow.
 
 ## Breaking v4.0.0
 

--- a/packages/array.utils/src/defined/README.md
+++ b/packages/array.utils/src/defined/README.md
@@ -8,20 +8,14 @@ import '@hansogj/array.utils';
 
 ```typescript
 // import as functions
-import {defined, definedList} from 'array.utils';
+import { defined, definedList } from '@hansogj/array.utils';
 
 defined(null); // => false
 defined(undefined); // => false
-definedList([1, 2]); // => [1,2]
-definedList([undefined, null]) // => []
-    [
-        // filter first
-        (1, 2, 3)
-    ].first() // => [1]
-    [
-        // filter last
-        (1, 2, 3)
-    ].last(); // => [3]
+definedList([1, 2]); // => [1, 2]
+definedList([undefined, null]); // => []
+[1, 2, 3].first(); // => [1]
+[1, 2, 3].last(); // => [3]
 ```
 
 ### Template for wrapping immutable lists
@@ -51,16 +45,26 @@ const {defined, definedList} = arrayDefined;
 console.log(defined([1])); // => [1]
 ```
 
+### Usage as a clean ESM sub-entry
+
+```ts
+import { defined, definedList } from '@hansogj/array.utils/defined';
+
+defined(null); // => false
+definedList([1, undefined, 2]); // => [1, 2]
+```
+
 ### Usage with Vanilla js
 
-```js
-// index.html
+```html
+<!-- index.html -->
 <script src="../node_modules/@hansogj/array.utils/dist/index.js"></script>
 <script src="../node_modules/@hansogj/array.utils/dist/defined/index.js"></script>
-
-// index.js
-const {defined, definedList} = window.defined;
-console.log(defined([1])); // => [1]
+<script>
+  // window globals exposed by each UMD bundle
+  const { defined, definedList } = window.defined;
+  console.log(defined([1])); // => [1]
+</script>
 ```
 
 ## Breaking v2.0.0

--- a/packages/find-js/README.md
+++ b/packages/find-js/README.md
@@ -8,24 +8,36 @@ Returns an iterable array of node-elements.
 
 ## Usage
 
-### JS
+### ESM (bundler / Node ≥18)
 
 ```js
-// either
-const find = require("@hansogj/find-js").default;
+import find from '@hansogj/find-js';
 
-//or
-<script src="../node_modules/@hansogj/find-js/dist/index.js"></script>
-const find = window.find.default;
-
-----
 console.log(find('h2', window.document.body));
 ```
 
-### TS
+### CommonJS
+
+```js
+const find = require('@hansogj/find-js').default;
+
+console.log(find('h2', window.document.body));
+```
+
+### Vanilla `<script>` tag
+
+```html
+<script src="../node_modules/@hansogj/find-js/dist/index.js"></script>
+<script>
+  const find = window.find.default;
+  console.log(find('h2', window.document.body));
+</script>
+```
+
+### TypeScript
 
 ```ts
-import find from 'find-js';
+import find from '@hansogj/find-js';
 
 console.log(find('h2', window.document.body));
 ```


### PR DESCRIPTION
## Summary

Audit pass over all README files in the repo to bring them in line with the actual post-migration state. Found four documents with stale or wrong claims; the rest were either already correct (most package READMEs) or intentionally not maintainer-focused (`maybe`'s versioning section is shipped to npm and aimed at consumers).

## Fixes

- **Root README**
  - `harness/shared/scripts/build-deps.js` no longer reads `@hansogj/maybe` from `node_modules` — it's been a workspace package since #35. Updated the description.
  - Added the `pnpm run harness:e2e` line and a paragraph about the Playwright suite under `harness/e2e/`. Noted it's CI-only (not in pre-commit).

- **packages/find-js/README.md**
  - You asked for an `import ... from` example. Restructured into four sections (ESM, CJS, Vanilla `<script>`, TypeScript) so the modern ESM import gets first billing.
  - Fixed the TS example: was `import find from 'find-js'` (missing `@hansogj/` scope).

- **packages/abonnement-js/README.md**
  - Import path was `from "../src/abonnement"` — a relative path that only resolves inside the package source tree, not from a consumer. Fixed to `from '@hansogj/abonnement-js'`.
  - Closed an unbalanced paren in the example.
  - Replaced the `npm ci & npm build` build hint with a pointer to the monorepo's root README.

- **packages/array.utils/src/defined/README.md**
  - `import { ... } from 'array.utils'` was missing the `@hansogj/` scope.
  - Added the modern `@hansogj/array.utils/defined` sub-entry example — that subpath was added to the exports map in #36 but never reflected in the docs.
  - Cleaned up the vanilla `<script>` example.

## What I verified is correct (no change needed)

- All `pnpm run harness:*` and `pnpm web-{ts,cs,js} {serve|start}` commands match the actual root scripts and the apps' package.json scripts
- Vanilla-JS `<script src=".../dist/index.js">` paths reflect the harmonized UMD layout from #41
- Sub-READMEs for `array.utils/src/onEmpty` and `array.utils/src/flatMap` use the correct scoped imports
- `git-prompt`, `maybe`, `immer-reduxer` READMEs

## Test plan

- [x] `pnpm run pre-commit` green (308 + 31)
- [x] `pnpm run harness:e2e` — 3 passed
- [x] CI green