### PR TITLE
fix(git-prompt): handle branch names with >3 segments

### DIFF
--- a/packages/git-prompt/package.json
+++ b/packages/git-prompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hansogj/git-prompt",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Interactive prompts for git branch names and commit messages along the conventional-commits convention",
   "type": "commonjs",
   "bin": {

--- a/packages/git-prompt/src/git-prompts.spec.ts
+++ b/packages/git-prompt/src/git-prompts.spec.ts
@@ -52,6 +52,8 @@ describe('git-prompts', () => {
                 ['fix/AI', { initialType: 3 }],
                 ['fix/AI/got-it-all-wrong', { ticker: 'AI', initialType: 3, scope: '' }],
                 ['fix/-/got-it-all-wrong', { ticker: '-', initialType: 3, scope: '' }],
+                ['fix/AI/area/sub-area', { ticker: 'AI', initialType: 3, scope: '' }],
+                ['feat/team/AI/topic/v2', { ticker: 'team', initialType: 2, scope: '' }],
             ] as Array<[string, { initialType?: number; ticker?: string; scope?: string }]>)(
                 'when current branch is %j',
                 (currentBranch, expected) => {
@@ -101,6 +103,8 @@ describe('git-prompts', () => {
                 ['fix/AI', { initialType: 5, scope: 'AI' }],
                 ['fix/AI/got-it-all-wrong', { ticker: 'AI', initialType: 5, scope: 'got-it-all-wrong' }],
                 ['fix/-/got-it-all-wrong', { ticker: '-', initialType: 5, scope: 'got-it-all-wrong' }],
+                ['fix/AI/area/sub-area', { ticker: 'AI', initialType: 5, scope: 'area/sub-area' }],
+                ['feat/team/AI/topic/v2', { ticker: 'team', initialType: 4, scope: 'AI/topic/v2' }],
             ] as Array<[string, { initialType?: number; ticker?: string; scope?: string }]>)(
                 'when current branch is %j',
                 (currentBranch, expected) => {

--- a/packages/git-prompt/src/git-prompts.ts
+++ b/packages/git-prompt/src/git-prompts.ts
@@ -15,8 +15,11 @@ const splitBranchName = (currentBranch: string): BranchParts => {
     let scope = '';
 
     if (splits.length === 1) [type] = splits;
-    if (splits.length === 2) [type, scope] = splits;
-    if (splits.length === 3) [type, ticker, scope] = splits;
+    else if (splits.length === 2) [type, scope] = splits;
+    else {
+        [type, ticker] = splits;
+        scope = splits.slice(2).join('/');
+    }
     return { type, ticker, scope };
 };
 


### PR DESCRIPTION
## Summary
`splitBranchName` returned all defaults (type/ticker undefined, scope='') for any branch with 4+ slashes, silently dropping the entire parsed identity.

Extend the 3-segment behaviour: first segment is type, second is ticker, everything from the third onward joins back into scope with `/`. 3-segment branches behave unchanged.

## Test plan
- [ ] CI green across Node 20/22/25
- [ ] Existing 1/2/3-segment cases still produce identical prompt args
- [ ] New 4/5-segment cases produce expected `ticker` + slash-joined `scope`

🤖 Generated with [Claude Code](https://claude.com/claude-code)