### PR TITLE
fix(maybe): stringify preserves strings and produces valid JSON

### DIFF
--- a/packages/maybe/package.json
+++ b/packages/maybe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hansogj/maybe",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Maybe monad — safe handling of optional/nullable values",
   "main": "./dist/maybe.js",
   "types": "./dist/maybe.d.ts",

--- a/packages/maybe/src/maybe.spec.ts
+++ b/packages/maybe/src/maybe.spec.ts
@@ -159,12 +159,14 @@ describe('Maybe', () => {
   describe('stringify', () => {
     it.each([
       ['', ''],
+      ['hello', 'hello'],
+      ['he said "hi"', 'he said "hi"'],
       [1, '1'],
       [true, 'true'],
       [[], '[]'],
       [{}, '{}'],
-      [{ a: [] }, '{a:[]}'],
-      [{ a: { b: { c: [{}, 'a', 1, []] } } }, '{a:{b:{c:[{},a,1,[]]}}}'],
+      [{ a: [] }, '{"a":[]}'],
+      [{ a: { b: { c: [{}, 'a', 1, []] } } }, '{"a":{"b":{"c":[{},"a",1,[]]}}}'],
     ])("should stringify value %j to '%s'", (value: any, stringifiedValue: string) => {
       expect(maybe(value).stringify().valueOrThrow()).toEqual(stringifiedValue);
     });

--- a/packages/maybe/src/maybe.ts
+++ b/packages/maybe/src/maybe.ts
@@ -95,7 +95,8 @@ export class Maybe<Value> {
       ),
     );
 
-  stringify = (): Maybe<string> => this.map((value) => JSON.stringify(value).replace(/\"/g, ''));
+  stringify = (): Maybe<string> =>
+    this.map((value) => (typeof value === 'string' ? value : JSON.stringify(value)));
 
   // Static members
   static just<Value>(value: Value): Maybe<Value> {


### PR DESCRIPTION
## Summary
`stringify` ran `JSON.stringify(value).replace(/\"/g, '')`, stripping *every* double-quote in the result. That destroyed two things:

- Strings containing quotes: `'he said "hi"'` came back as `'he said \"hi\"'`.
- Objects/arrays: key quotes were stripped, producing invalid JSON like `{a:[]}` instead of `{"a":[]}`.

Replaced with: if the value is a string, return it as-is; otherwise `JSON.stringify(value)`. Primitives unchanged (`1`, `true`, `[]`, `{}`); objects/arrays now emit valid JSON.

The existing spec asserted the broken object output shape — updated to the corrected form.

## Test plan
- [ ] CI green
- [ ] Strings with internal quotes survive round-trip
- [ ] Object output parses as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)