### PR TITLE
docs: JSDoc on public APIs

### DIFF
--- a/packages/abonnement-js/src/abonnement.ts
+++ b/packages/abonnement-js/src/abonnement.ts
@@ -5,6 +5,22 @@ interface IndexedObject {
     [key: string]: any;
 }
 
+/**
+ * Lightweight observable. Holds a value of type `T` and notifies subscribers
+ * when it changes.
+ *
+ * API is in Norwegian:
+ *   `abonner`  — subscribe
+ *   `varsle`   — notify (publish a new value)
+ *   `avslutt`  — unsubscribe
+ *   `verdi`    — current value
+ *
+ * @example
+ *   const a = new Abonnement<number>(0);
+ *   const id = a.abonner((ny, gml) => console.log(ny, gml));
+ *   a.varsle(1);
+ *   a.avslutt(id);
+ */
 export class Abonnement<T> {
     protected abonnenter: ((nyVerdi: T, gammelVerdi: T) => void)[];
 
@@ -17,6 +33,11 @@ export class Abonnement<T> {
         this.aktuellVerdi = init;
     }
 
+    /**
+     * Subscribe to value changes. Returns the subscriber's id (use it with
+     * `avslutt`). When `callOnInit` is true (default) the callback is invoked
+     * immediately with the current value, provided that value is truthy.
+     */
     abonner(abonnent: (nyVerdi: T, gmlVerdi?: T) => void, callOnInit: boolean = true): number {
         const length: number = this.abonnenter.push(abonnent);
         if (this.aktuellVerdi && callOnInit) {
@@ -25,6 +46,11 @@ export class Abonnement<T> {
         return length - 1;
     }
 
+    /**
+     * Publish a new value. Subscribers are called with `(newValue, oldValue)`.
+     * The first call is always delivered, even when the new value is the
+     * same as the old.
+     */
     varsle(nyVerdi: T): T {
         this.abonnenter.map((fn) => {
             if (defined(nyVerdi) || defined(this.aktuellVerdi) || this.ren) {
@@ -36,19 +62,27 @@ export class Abonnement<T> {
         return nyVerdi;
     }
 
+    /** Current value. */
     get verdi(): T {
         return this.aktuellVerdi;
     }
 
+    /** Unsubscribe by id (returned from `abonner`). */
     avslutt(id: number) {
         this.abonnenter = this.abonnenter.filter((_, i) => i !== id);
     }
 
+    /** Test-only inspection of the subscriber list. */
     get __test(): IndexedObject {
         return { abonnenter: this.abonnenter };
     }
 }
 
+/**
+ * Combines several `Abonnement`s into one. Subscribers are notified with an
+ * array of every source's current value, but only once **all** sources have
+ * defined values. Compare with `JoinedAbonnement`, which fires on any change.
+ */
 export class AlleAbonnementer<T> extends Abonnement<T> {
     private avsluttListe: number[];
 
@@ -71,6 +105,12 @@ export class AlleAbonnementer<T> extends Abonnement<T> {
     }
 }
 
+/**
+ * Combines several `Abonnement`s into one. Subscribers are notified every
+ * time **any** source publishes, with the array of all current values
+ * (defined or not). Compare with `AlleAbonnementer`, which waits until every
+ * source has a value.
+ */
 export class JoinedAbonnement<T> extends Abonnement<T> {
     private avsluttListe: number[];
 

--- a/packages/array.utils/src/defined/defined.ts
+++ b/packages/array.utils/src/defined/defined.ts
@@ -1,3 +1,22 @@
+/**
+ * `true` if `prop` is meaningfully present.
+ *
+ * Treats `null`/`undefined` as undefined; for collections (with `length` or
+ * `size`) requires non-emptiness; for booleans returns the boolean itself.
+ * Functions, plain objects, numbers (including `0`), and non-empty strings
+ * return `true`.
+ *
+ * @example
+ *   defined(undefined)   // false
+ *   defined(null)        // false
+ *   defined([])          // false  (length is 0)
+ *   defined([0])         // true
+ *   defined('')          // false  (length is 0)
+ *   defined('x')         // true
+ *   defined(new Set())   // false  (size is 0)
+ *   defined(false)       // false
+ *   defined(0)           // true
+ */
 export const defined = <T>(prop: T): boolean => {
     if (prop === undefined || prop === null) {
         return false;

--- a/packages/array.utils/src/defined/definedList.ts
+++ b/packages/array.utils/src/defined/definedList.ts
@@ -1,6 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { defined } from './defined';
 
+/**
+ * Coerce `prop` into an array of "defined" items.
+ *
+ * - If `prop` is itself undefined/null, returns `[]`.
+ * - If `prop` is an array, returns it filtered by `defined`.
+ * - Otherwise wraps `prop` in a single-element array, then filters.
+ *
+ * @example
+ *   definedList([1, null, 2])  // [1, 2]
+ *   definedList(undefined)     // []
+ *   definedList('x')           // ['x']
+ *   definedList('')            // []
+ */
 export const definedList = <T>(prop: T): T[] => {
     if (!defined(prop) || !defined((prop as T[]).constructor)) {
         return [];

--- a/packages/array.utils/src/defined/polyfill.ts
+++ b/packages/array.utils/src/defined/polyfill.ts
@@ -4,9 +4,13 @@ import { definedList } from './definedList';
 
 declare global {
     interface Array<T> {
+        /** Returns a new array with only the `defined` items. See `defined()`. */
         defined(): Array<T>;
+        /** Returns `this` if every item is defined; otherwise an empty array. */
         allDefined(): Array<T>;
+        /** Returns a single-element array containing the first item. */
         first(): Array<T>;
+        /** Returns a single-element array containing the last item. */
         last(): Array<T>;
     }
 }

--- a/packages/array.utils/src/onEmpty/onEmpty.ts
+++ b/packages/array.utils/src/onEmpty/onEmpty.ts
@@ -1,5 +1,12 @@
 declare global {
     interface Array<T> {
+        /**
+         * Run `cb(self)` only when the array is empty, then always return
+         * the array — fluent escape-hatch for empty-state side effects.
+         *
+         * @example
+         *   results.onEmpty(() => log('no results')).map(render);
+         */
         onEmpty: (cb: (self: Array<T>) => Array<T>) => Array<T>;
     }
 }

--- a/packages/find-js/src/find.ts
+++ b/packages/find-js/src/find.ts
@@ -1,2 +1,12 @@
+/**
+ * Run `root.querySelectorAll(selector)` and return the result as a real
+ * `Array<T>`, so you can chain `.map`/`.filter`/etc. directly.
+ *
+ * Defaults the root to the current `window.document`.
+ *
+ * @example
+ *   find<HTMLAnchorElement>('nav a').map((a) => a.href);
+ *   find('.row', tableEl).forEach(highlight);
+ */
 export default <T = HTMLElement>(selector: string, root: Document | HTMLElement = window.document): Array<T> =>
     Array.from(root.querySelectorAll(selector) as unknown as T[]);

--- a/packages/maybe/src/maybe.ts
+++ b/packages/maybe/src/maybe.ts
@@ -1,5 +1,25 @@
+/**
+ * A value that may be present or absent (`undefined` / `null`).
+ *
+ * Used as `T | undefined` in type signatures throughout `Maybe`.
+ */
 export type Optional<T> = T | undefined;
 
+/**
+ * Container for an optional value with helpers for safe mapping, default
+ * extraction, and conditional side-effects. Treat `null` and `undefined` as
+ * the same "nothing" state; everything else (including `0`, `''`, `false`,
+ * `{}`, `[]`) is "something".
+ *
+ * Prefer the `maybe()` factory or `Maybe.just` / `Maybe.nothing` over
+ * constructing directly.
+ *
+ * @example
+ *   maybe(user)
+ *     .mapTo('email')
+ *     .ifSomething(send)
+ *     .valueOr('no email');
+ */
 export class Maybe<Value> {
   private readonly wrappedValue: Optional<Value>;
 
@@ -7,10 +27,11 @@ export class Maybe<Value> {
     this.wrappedValue = wrappedValue;
   }
 
-  // Extracting the value
+  /** Return the wrapped value, or `defaultValue` if nothing. */
   valueOr = <T>(defaultValue: T): Value | T =>
     Maybe.isSomething(this.wrappedValue) ? this.wrappedValue : defaultValue;
 
+  /** Return the wrapped value, or throw `error` if nothing. */
   valueOrThrow = (
     error: Error = new TypeError('Wrapped value is undefined or null'),
   ): Value | never =>
@@ -18,24 +39,31 @@ export class Maybe<Value> {
       throw error;
     });
 
+  /** Return the wrapped value, or the result of `closure()` if nothing. */
   valueOrExecute = <T>(closure: () => T | Value): T | Value =>
     Maybe.isSomething(this.wrappedValue) ? this.wrappedValue : closure();
 
-  // Existence checking
+  /** `true` if a non-null value is wrapped. */
   isSomething = (): boolean => !this.isNothing();
 
+  /** `true` if the wrapped value is `null` or `undefined`. */
   isNothing = (): boolean => this.wrappedValue === undefined || this.wrappedValue === null;
 
-  // Mapping
+  /**
+   * Apply `mapper` to the wrapped value and return a new `Maybe`. If the
+   * current Maybe is nothing, or `mapper` returns `undefined`/`null`, the
+   * result is nothing.
+   */
   map = <Output>(mapper: (value: Value) => Optional<Output>): Maybe<Output> =>
     // eslint-disable-next-line
     // @ts-ignore
     this.isNothing() ? Maybe.nothing() : new Maybe(mapper(this.wrappedValue));
 
+  /** Like `map`, but `mapper` already returns a `Maybe`. Flattens the result. */
   flatMap = <Output>(mapper: (value: Value) => Maybe<Output>): Maybe<Output> =>
     this.map(mapper).map((it) => it.wrappedValue);
 
-  // runs callback without changing value
+  /** Run `callback` with the value (for side effects), then return `this`. */
   tap = (callback: (val: Value) => unknown) => {
     // eslint-disable-next-line
     // @ts-ignore
@@ -43,7 +71,7 @@ export class Maybe<Value> {
     return this;
   };
 
-  // Conditional callbacks
+  /** Run `callback` only when the value is nothing. Returns `this`. */
   ifNothing = (callback: () => void): Maybe<Value> => {
     if (this.isNothing()) {
       callback();
@@ -51,36 +79,50 @@ export class Maybe<Value> {
     return this;
   };
 
+  /** Run `callback` only when the value is something. Returns `this`. */
   ifSomething = (callback: (_: Value) => void): Maybe<Value> =>
     this.map((value) => {
       callback(value);
       return value;
     });
 
-  // Filtering
+  /** Keep the value only if `filter` returns true; otherwise become nothing. */
   nothingUnless = (filter: (_: Value) => boolean): Maybe<Value> =>
     this.map((value) => (filter(value) ? value : undefined));
 
+  /** Become nothing if `filter` returns true. */
   nothingIf = (filter: (_: Value) => boolean): Maybe<Value> =>
     this.nothingUnless((it) => !filter(it));
 
+  /** Keep the value only if it is truthy. */
   ifTrue = () => this.nothingUnless((value: Value) => Boolean(value));
 
+  /** Keep the value only if it is falsy. */
   ifFalse = () => this.nothingUnless((value: Value) => !Boolean(value));
 
-  // Utilities
+  /** If nothing, return `other`; otherwise return `this`. */
   or = (other: Maybe<Value>): Maybe<Value> => (this.isNothing() ? other : this);
 
+  /** If nothing, return `Maybe.just(other)`; otherwise return `this`. */
   orJust = (other: Value): Maybe<Value> => (this.isNothing() ? Maybe.just(other) : this);
 
+  /**
+   * Combine two Maybes into a Maybe of `[Value, OtherValue]`. The result is
+   * nothing if either side is nothing.
+   */
   zip<OtherValue>(other: Maybe<OtherValue>): Maybe<[Value, OtherValue]> {
     return this.map(
       (it) => other.map((t: OtherValue): [Value, OtherValue] => [it, t]).wrappedValue,
     );
   }
 
+  /** Project to a property of the wrapped value (typed). */
   mapTo = <Key extends keyof Value>(key: Key): Maybe<Value[Key]> => this.map((value) => value[key]);
 
+  /**
+   * Build a new object containing only the picked keys whose values are
+   * something. Keys whose values are nothing are silently omitted.
+   */
   pick = <Key extends keyof Value>(...keys: Key[]): Maybe<Record<Key, Value[Key]>> =>
     new Maybe(
       keys.reduce(
@@ -95,27 +137,45 @@ export class Maybe<Value> {
       ),
     );
 
+  /**
+   * Stringify the wrapped value. Strings return as-is (no JSON wrapping
+   * quotes); everything else uses `JSON.stringify`.
+   *
+   * @example
+   *   maybe('hello').stringify().valueOr('');        // → 'hello'
+   *   maybe({ a: 1 }).stringify().valueOr('');       // → '{"a":1}'
+   */
   stringify = (): Maybe<string> =>
     this.map((value) => (typeof value === 'string' ? value : JSON.stringify(value)));
 
-  // Static members
+  /** Wrap a value (which may be nothing) in a `Maybe`. */
   static just<Value>(value: Value): Maybe<Value> {
     return new Maybe<Value>(value);
   }
 
+  /** A `Maybe` representing the absence of a value. */
   static nothing<Value>(): Maybe<Value> {
     return new Maybe<Value>(undefined);
   }
 
+  /** Type guard: `true` if `value` is not `null`/`undefined`. */
   static isSomething<Value>(value: Optional<Value>): value is Value {
     return !this.isNothing(value);
   }
 
+  /** Type guard: `true` if `value` is `null` or `undefined`. */
   static isNothing<Value>(value: Optional<Value>): value is undefined {
     return new Maybe(value).isNothing();
   }
 }
 
+/**
+ * Construct a `Maybe<Value>` from a possibly-absent value. Equivalent to
+ * `Maybe.just(value)` for non-null, `Maybe.nothing()` otherwise.
+ *
+ * @example
+ *   maybe(user).mapTo('email').valueOr('no email');
+ */
 export default function maybe<Value>(value: Optional<Value>): Maybe<Value> {
   if (Maybe.isNothing(value)) {
     return Maybe.nothing();


### PR DESCRIPTION
## Summary
Adds JSDoc descriptions (and a few `@example` snippets) to every exported symbol of the libraries with a public API:

- **`@hansogj/maybe`** — `Maybe` class, every instance/static method, the `maybe()` factory, and the `Optional<T>` alias.
- **`@hansogj/array.utils`** — `defined`, `definedList`, and the Array prototype extensions (`defined`, `allDefined`, `first`, `last`, `onEmpty`).
- **`@hansogj/find-js`** — the default export.
- **`@hansogj/abonnement-js`** — `Abonnement` and its `AlleAbonnementer` / `JoinedAbonnement` subclasses, with a Norwegian-API translation note.

`@hansogj/git-prompt` is intentionally skipped — its `package.json` `exports` map is empty (CLI-only package, no library consumers).

No runtime changes. Versions intentionally **not** bumped — JSDoc enters published `.d.ts`, but consumers only see it on the next release pass. This avoids collision with the version bumps in #45 and #46.

## Test plan
- [ ] CI green
- [ ] `pnpm run ws:ts` clean across packages
- [ ] Hover help on a `maybe(...)` / `defined(...)` / `find(...)` call shows the new JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)