### PR TITLE
docs: scaffold CHANGELOG.md per published package

### DIFF
--- a/packages/abonnement-js/CHANGELOG.md
+++ b/packages/abonnement-js/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `@hansogj/abonnement-js`. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/).
+
+Older history before the move into the `utils-ws` monorepo lives in git tags.
+
+## [Unreleased]
+
+### Added
+- JSDoc on `Abonnement`, `AlleAbonnementer`, `JoinedAbonnement` (with a note about the Norwegian-API translations: `abonner` = subscribe, `varsle` = notify, `avslutt` = unsubscribe, `verdi` = value). ([#47])
+
+## [4.7.5] – 2026-06-13
+
+### Changed
+- Harmonized package shape across all workspace libraries. ([#41])
+
+## [4.7.4] – earlier 2026
+
+### Added
+- Modernized packaging: dual ESM (`.mjs`) + CJS (`.cjs`) exports via Vite, UMD (`.js`) for script-tag consumers. ([#39])
+
+[#39]: https://github.com/hansogj/utils-ws/pull/39
+[#41]: https://github.com/hansogj/utils-ws/pull/41
+[#47]: https://github.com/hansogj/utils-ws/pull/47

--- a/packages/array.utils/CHANGELOG.md
+++ b/packages/array.utils/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `@hansogj/array.utils`. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/).
+
+Older history before the move into the `utils-ws` monorepo lives in git tags.
+
+## [Unreleased]
+
+### Removed
+- **Breaking:** dropped the `flatMap` polyfill — `Array.prototype.flatMap` has been native since Node 11 / ES2019, so the `||` fallback never ran. The `./flatMap` sub-entry is gone; consumers importing it explicitly must drop the import. ([#46])
+
+### Added
+- JSDoc on `defined`, `definedList`, and the prototype extensions (`defined`, `allDefined`, `first`, `last`, `onEmpty`) — shows up in editor hover and published `.d.ts`. ([#47])
+
+## [2.7.5] – 2026-06-13
+
+### Changed
+- Harmonized package shape across all workspace libraries: matching `exports` map, `sideEffects`, and filename convention (`.mjs` ESM, `.cjs` CJS, `.js` UMD). ([#41])
+
+## [2.7.4] – earlier 2026
+
+### Added
+- Modernized packaging: `"type": "module"`, dual ESM/CJS exports via Vite, multi-entry UMD via webpack for the script-tag harness. ([#36])
+
+[#36]: https://github.com/hansogj/utils-ws/pull/36
+[#41]: https://github.com/hansogj/utils-ws/pull/41
+[#46]: https://github.com/hansogj/utils-ws/pull/46
+[#47]: https://github.com/hansogj/utils-ws/pull/47

--- a/packages/find-js/CHANGELOG.md
+++ b/packages/find-js/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `@hansogj/find-js`. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/).
+
+Older history before the move into the `utils-ws` monorepo lives in git tags.
+
+## [Unreleased]
+
+### Added
+- JSDoc with usage examples on the default export. ([#47])
+
+## [6.7.5] – 2026-06-13
+
+### Changed
+- Harmonized package shape across all workspace libraries. ([#41])
+
+## [6.7.4] – earlier 2026
+
+### Added
+- Modernized packaging: dual ESM (`.mjs`) + CJS (`.cjs`) exports via Vite, UMD (`.js`) for script-tag consumers, `"type": "module"`. ([#37])
+
+[#37]: https://github.com/hansogj/utils-ws/pull/37
+[#41]: https://github.com/hansogj/utils-ws/pull/41
+[#47]: https://github.com/hansogj/utils-ws/pull/47

--- a/packages/git-prompt/CHANGELOG.md
+++ b/packages/git-prompt/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `@hansogj/git-prompt`. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/).
+
+Older history before the move into the `utils-ws` monorepo lives in git tags.
+
+## [Unreleased]
+
+### Fixed
+- `splitBranchName` no longer silently drops the entire branch identity for branches with 4+ segments. The first segment becomes `type`, the second becomes `ticker`, everything from the third onward joins back into `scope` with `/`. 3-segment behaviour is unchanged. ([#44])
+
+## [0.5.2] – 2026-06-13
+
+### Changed
+- Harmonized package metadata with the rest of the workspace. ([#41])
+
+## [0.5.1] – earlier 2026
+
+### Added
+- Modernized `package.json` metadata (description, keywords, repository, bugs, homepage); converted source to TypeScript with a CommonJS output bundled by `@vercel/ncc`. ([#40])
+
+## Earlier — `wip` type and commit-only filter
+
+The conventional types list gained `wip` (work-in-progress) as a commit-only type — together with `chore` and `docs`, these can't be used as branch prefixes. The `wip` type intentionally skips the strict subject rules so it can serve as a quick collaborator-handoff signal.
+
+[#40]: https://github.com/hansogj/utils-ws/pull/40
+[#41]: https://github.com/hansogj/utils-ws/pull/41
+[#44]: https://github.com/hansogj/utils-ws/pull/44

--- a/packages/maybe/CHANGELOG.md
+++ b/packages/maybe/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to `@hansogj/maybe`. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/).
+
+Earlier history (pre-monorepo) lives in the original `@hansogj/maybe` repository's git tags.
+
+## [Unreleased]
+
+### Fixed
+- `stringify` now preserves strings as-is and emits valid JSON for objects/arrays. The previous implementation ran `JSON.stringify(value).replace(/\"/g, '')`, which destroyed every double-quote in the output — mangling strings with internal quotes and producing invalid JSON for objects (`{a:[]}` instead of `{"a":[]}`). ([#45])
+
+### Added
+- JSDoc on the `Maybe` class, every instance/static method, the `maybe()` factory, and the `Optional<T>` alias. ([#47])
+
+## [2.7.0] – 2026-03-28
+
+### Changed
+- Integrated into the `utils-ws` monorepo from the standalone `@hansogj/maybe` repository. ([#35])
+- Modernized packaging: dual ESM (`.mjs`) + CJS (`.cjs`) exports via Vite, UMD (`.js`) for script-tag consumers. ([#38])
+- Harmonized package shape with the rest of the workspace. ([#41])
+
+[#35]: https://github.com/hansogj/utils-ws/pull/35
+[#38]: https://github.com/hansogj/utils-ws/pull/38
+[#41]: https://github.com/hansogj/utils-ws/pull/41
+[#45]: https://github.com/hansogj/utils-ws/pull/45
+[#47]: https://github.com/hansogj/utils-ws/pull/47


### PR DESCRIPTION
## Summary
Adds a Keep-a-Changelog file for each of the five workspace packages with a library API: `array.utils`, `abonnement-js`, `find-js`, `git-prompt`, `maybe`.

Each file backfills the most recent modernization-era versions (PRs #35–#41) and lists pending changes under `[Unreleased]` from the currently-in-flight PRs #44–#47. Older history (pre-monorepo, pre-modernization) is referenced via git tags rather than copied in.

The CHANGELOG files are intentionally **not** added to `package.json#files` — they live on GitHub only, kept off the published tarball to avoid the maintenance overhead of keeping them perfectly in sync with each release.

No code changes; no version bumps.

## Test plan
- [ ] CI green
- [ ] All five `CHANGELOG.md` render correctly on GitHub
- [ ] Links to PRs #35–#47 resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)