### PR TITLE
feat(harness): add shouldIt branch-driven test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,38 @@ Versions shown in the apps come from a single source of truth: `harness/shared/s
 
 The Playwright suite lives in `harness/e2e/` — it boots http-servers for the three built apps via `playwright.config.ts`'s `webServer` block and asserts on the rendered DOM (heading, version list, success/error `<pre>` counts). Catches build-time regressions that the in-process jest tests miss — e.g. the tree-shaking-vs-polyfill issue that surfaced during the array.utils modernization.
 
+## Testing helper: `shouldIt`
+
+`harness/shared/src/should-it.js` is a small, framework-agnostic helper for writing branch-driven test names — `should X` / `should not X` — that only register the relevant branch. Useful when a single parametrised describe needs to assert one thing in the positive case and a different thing in the negative case, without an ugly `if` ladder.
+
+The implementation is intentionally tiny and **not published as a package** — it's shipped alongside the harness lib so any workspace consumer can `require('shared')` it (the harness apps already do). It works with Jest, Vitest, and any runner exposing a `test(name, fn, timeout)` signature.
+
+```ts
+import { createShouldIt } from 'shared';
+
+const should = createShouldIt(test); // pass your runner's `test`
+
+describe.each([
+  ['<ul><li>1</li></ul>', true],
+  ['<div>no list</div>', false],
+])('find("li") in %s', (template, hasItems) => {
+  beforeEach(() => { document.body.innerHTML = template; });
+
+  should('return at least one element', hasItems).then(() =>
+    expect(find('li').length).toBeGreaterThan(0)
+  );
+  should('return any elements', hasItems).dont(() =>
+    expect(find('li')).toHaveLength(0)
+  );
+});
+```
+
+`should(description, condition).then(body)` registers `should <description>` only when `condition` is true; `.dont(body)` registers `should not <description>` only when it's false. `.then(body, toBe)` appends `JSON.stringify(toBe)` to the label for parametrised expectations.
+
+A bare `shouldIt` export is also available — it resolves the runner's `test` via global lookup at call time, for codebases that already rely on Jest's / Vitest's global injection. Prefer the explicit `createShouldIt(test)` factory in new code.
+
+A `might(condition: boolean)` helper is also exported — returns `'should'` or `'should not'` — handy for building dynamic describe labels independently of the chain.
+
 ## Versioning
 
 The pnpm-script _ws:version:set:all_ will ensure all packages are updated with same strategy, and git tagging is done right

--- a/apps/web-cs/src/run.js
+++ b/apps/web-cs/src/run.js
@@ -1,4 +1,4 @@
-const { suite, dependencies, verify, versions } = require('shared');
+const { suite, dependencies, verify, versions, createShouldIt, might } = require('shared');
 const Abonnement = require("@hansogj/abonnement-js").Abonnement;
 const find = require("@hansogj/find-js").default;
 const maybe = require("@hansogj/maybe").default;
@@ -40,4 +40,28 @@ export const run = () => {
 
         .after((numberOfTests) => verify('expect to have ran 6 tests', () => numberOfTests).toEqual(6));
 
+    let skippedBodyRan = false;
+    const sbShouldIt = suite("shouldIt verification")
+        .before(() => { skippedBodyRan = false; });
+    const should = createShouldIt((name, fn) => sbShouldIt.test(name, fn));
+
+    should("include the `should` prefix on positive cases", true)
+        .then(() => verify("positive body ran", () => "ran").toEqual("ran"));
+    should("include the `should not` prefix on negative cases", false)
+        .dont(() => verify("negative body ran", () => "ran").toEqual("ran"));
+
+    should("not register .then when condition is false", false)
+        .then(() => { skippedBodyRan = true; });
+    should("not register .dont when condition is true", true)
+        .dont(() => { skippedBodyRan = true; });
+
+    sbShouldIt
+        .test("skipped bodies were never invoked", () =>
+            verify("skippedBodyRan", () => skippedBodyRan).toEqual(false))
+        .test("might() helper", () => {
+            verify("might(true)", () => might(true)).toEqual("should");
+            verify("might(false)", () => might(false)).toEqual("should not");
+        })
+        .after((numberOfTests) =>
+            verify("expected 4 registered tests", () => numberOfTests).toEqual(4));
 };

--- a/apps/web-cs/src/should-it.spec.js
+++ b/apps/web-cs/src/should-it.spec.js
@@ -1,0 +1,63 @@
+const { createShouldIt, might, shouldIt } = require('shared');
+
+describe('might', () => {
+    it('returns "should" when true', () => expect(might(true)).toBe('should'));
+    it('returns "should not" when false', () => expect(might(false)).toBe('should not'));
+});
+
+describe('createShouldIt — unit (mocked testFn) via CJS', () => {
+    let testFn;
+    let it$;
+
+    beforeEach(() => {
+        testFn = jest.fn();
+        it$ = createShouldIt(testFn);
+    });
+
+    it('registers via .then when condition is true', () => {
+        it$('do the thing', true).then(() => { });
+        expect(testFn).toHaveBeenCalledWith('should do the thing', expect.any(Function), undefined);
+    });
+
+    it('registers via .dont when condition is false', () => {
+        it$('do the thing', false).dont(() => { });
+        expect(testFn).toHaveBeenCalledWith('should not do the thing', expect.any(Function), undefined);
+    });
+
+    it('appends JSON.stringify(toBe) on .then', () => {
+        it$('answer with', true, [1, 2]).then(() => { });
+        expect(testFn).toHaveBeenCalledWith('should answer with [1,2]', expect.any(Function), undefined);
+    });
+
+    it('is chainable', () => {
+        it$('be chainable', true).then(() => { }).dont(() => { });
+        expect(testFn).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('shouldIt — global-test convenience via CJS', () => {
+    const captured = [];
+    const recordingTest = (name, fn, timeout) => {
+        captured.push(name);
+        test(name, fn || (() => { }), timeout);
+    };
+    const it$ = createShouldIt(recordingTest);
+
+    it$('echo via CJS', true).then(() => expect(true).toBe(true));
+    it$('explode via CJS', false).dont(() => expect(true).toBe(true));
+
+    test('recorded the expected names', () =>
+        expect(captured).toEqual(['should echo via CJS', 'should not explode via CJS']));
+
+    test('shouldIt convenience falls back to global `test`', () => {
+        const labels = [];
+        const original = globalThis.test;
+        globalThis.test = (name) => labels.push(name);
+        try {
+            shouldIt('use the global test', true).then(() => { });
+        } finally {
+            globalThis.test = original;
+        }
+        expect(labels).toEqual(['should use the global test']);
+    });
+});

--- a/apps/web-js/index.html
+++ b/apps/web-js/index.html
@@ -25,6 +25,7 @@
     <script src="/shared/src/verify.js"></script>
     <script src="/shared/src/test.suite.js"></script>
     <script src="/shared/src/dependencies.js"></script>
+    <script src="/shared/src/should-it.js"></script>
     <script src="./src/run.js"></script>
     <script type="text/javascript">
         window.run();

--- a/apps/web-js/src/run.js
+++ b/apps/web-js/src/run.js
@@ -33,4 +33,32 @@ window.run = () => {
                     .valueOrExecute(() => "no ul in set")
             ).toEqual("UL");
         }).after((numberOfTests) => verify('expect to have ran 5 tests', () => numberOfTests).toEqual(5));
+
+    const createShouldIt = window.createShouldIt;
+    const might = window.might;
+
+    let skippedBodyRan = false;
+    const sbShouldIt = suite("shouldIt verification")
+        .before(() => { skippedBodyRan = false; });
+    const should = createShouldIt((name, fn) => sbShouldIt.test(name, fn));
+
+    should("include the `should` prefix on positive cases", true)
+        .then(() => verify("positive body ran", () => "ran").toEqual("ran"));
+    should("include the `should not` prefix on negative cases", false)
+        .dont(() => verify("negative body ran", () => "ran").toEqual("ran"));
+
+    should("not register .then when condition is false", false)
+        .then(() => { skippedBodyRan = true; });
+    should("not register .dont when condition is true", true)
+        .dont(() => { skippedBodyRan = true; });
+
+    sbShouldIt
+        .test("skipped bodies were never invoked", () =>
+            verify("skippedBodyRan", () => skippedBodyRan).toEqual(false))
+        .test("might() helper", () => {
+            verify("might(true)", () => might(true)).toEqual("should");
+            verify("might(false)", () => might(false)).toEqual("should not");
+        })
+        .after((numberOfTests) =>
+            verify("expected 4 registered tests", () => numberOfTests).toEqual(4));
 }

--- a/apps/web-ts/src/run.ts
+++ b/apps/web-ts/src/run.ts
@@ -4,7 +4,7 @@ import '@hansogj/array.utils';
 import { defined, definedList } from '@hansogj/array.utils';
 import find from '@hansogj/find-js';
 import maybe from '@hansogj/maybe';
-import { dependencies, suite, verify, versions } from 'shared';
+import { createShouldIt, dependencies, might, suite, verify, versions } from 'shared';
 
 export const run = () => {
   suite('Module include')
@@ -46,4 +46,36 @@ export const run = () => {
       abonnement.abonner((val) => verify('@hansogj/abonnement', () => val).toDiffer('init'));
     })
     .after((numberOfTests: number) => verify('expect to have ran 6 tests', () => numberOfTests).toEqual(6));
+
+  let skippedBodyRan = false;
+  const sbShouldIt = suite('shouldIt verification').before(() => {
+    skippedBodyRan = false;
+  });
+  const should = createShouldIt((name, fn) => sbShouldIt.test(name, fn));
+
+  should('include the `should` prefix on positive cases', true).then(() =>
+    verify('positive body ran', () => 'ran').toEqual('ran')
+  );
+  should('include the `should not` prefix on negative cases', false).dont(() =>
+    verify('negative body ran', () => 'ran').toEqual('ran')
+  );
+
+  should('not register .then when condition is false', false).then(() => {
+    skippedBodyRan = true;
+  });
+  should('not register .dont when condition is true', true).dont(() => {
+    skippedBodyRan = true;
+  });
+
+  sbShouldIt
+    .test('skipped bodies were never invoked', () =>
+      verify('skippedBodyRan', () => skippedBodyRan).toEqual(false)
+    )
+    .test('might() helper', () => {
+      verify('might(true)', () => might(true)).toEqual('should');
+      verify('might(false)', () => might(false)).toEqual('should not');
+    })
+    .after((numberOfTests: number) =>
+      verify('expected 4 registered tests', () => numberOfTests).toEqual(4)
+    );
 };

--- a/apps/web-ts/src/should-it.spec.ts
+++ b/apps/web-ts/src/should-it.spec.ts
@@ -1,0 +1,102 @@
+import { createShouldIt, might, shouldIt } from 'shared';
+
+describe('might', () => {
+  it('returns "should" when true', () => expect(might(true)).toBe('should'));
+  it('returns "should not" when false', () => expect(might(false)).toBe('should not'));
+});
+
+describe('createShouldIt — unit (mocked testFn)', () => {
+  let testFn: jest.Mock;
+  let it$: ReturnType<typeof createShouldIt>;
+
+  beforeEach(() => {
+    testFn = jest.fn();
+    it$ = createShouldIt(testFn);
+  });
+
+  describe('.then', () => {
+    it('registers a test when condition is true', () => {
+      const body = () => {};
+      it$('greet the world', true).then(body);
+      expect(testFn).toHaveBeenCalledTimes(1);
+      expect(testFn).toHaveBeenCalledWith('should greet the world', body, undefined);
+    });
+
+    it('is a no-op when condition is false', () => {
+      it$('greet the world', false).then(() => {});
+      expect(testFn).not.toHaveBeenCalled();
+    });
+
+    it('appends a JSON-stringified toBe value to the test name', () => {
+      it$('return', true, { answer: 42 }).then(() => {});
+      expect(testFn).toHaveBeenCalledWith('should return {"answer":42}', expect.any(Function), undefined);
+    });
+
+    it('does NOT append toBe when toBe is falsy (0, false, "") — bug-for-bug from the original', () => {
+      it$('count', true, 0).then(() => {});
+      expect(testFn).toHaveBeenCalledWith('should count', expect.any(Function), undefined);
+    });
+
+    it('forwards the timeout argument', () => {
+      it$('be patient', true).then(() => {}, 5000);
+      expect(testFn).toHaveBeenCalledWith('should be patient', expect.any(Function), 5000);
+    });
+  });
+
+  describe('.dont', () => {
+    it('registers a test when condition is false', () => {
+      it$('explode', false).dont(() => {});
+      expect(testFn).toHaveBeenCalledWith('should not explode', expect.any(Function), undefined);
+    });
+
+    it('is a no-op when condition is true', () => {
+      it$('explode', true).dont(() => {});
+      expect(testFn).not.toHaveBeenCalled();
+    });
+
+    it('does NOT append toBe to the negative-case label', () => {
+      it$('return', false, { answer: 42 }).dont(() => {});
+      expect(testFn).toHaveBeenCalledWith('should not return', expect.any(Function), undefined);
+    });
+  });
+
+  describe('chaining', () => {
+    it('exposes both .then and .dont on a single call, exactly one fires per condition', () => {
+      it$('be lazy', true)
+        .then(() => {})
+        .dont(() => {});
+      it$('be lazy', false)
+        .then(() => {})
+        .dont(() => {});
+      expect(testFn).toHaveBeenCalledTimes(2);
+      expect(testFn.mock.calls.map((c) => c[0])).toEqual(['should be lazy', 'should not be lazy']);
+    });
+  });
+});
+
+describe('shouldIt — integration with the real jest `test` global', () => {
+  const captured: string[] = [];
+  const recordingTest = ((name, fn, timeout) => {
+    captured.push(name);
+    test(name, fn ?? (() => {}), timeout);
+  }) as typeof test;
+  const it$ = createShouldIt(recordingTest);
+
+  it$('register a positive case', true).then(() => expect(true).toBe(true));
+  it$('register a negative case', false).dont(() => expect(false).toBe(false));
+
+  test('registered exactly the expected names', () =>
+    expect(captured).toEqual(['should register a positive case', 'should not register a negative case']));
+
+  test('the global shouldIt convenience falls back to global `test` when present', () => {
+    const labels: string[] = [];
+    const originalTest = (globalThis as { test?: unknown }).test;
+    (globalThis as { test?: unknown }).test = (name: string) => labels.push(name);
+    try {
+      shouldIt('use the global test', true).then(() => {});
+    } finally {
+      (globalThis as { test?: unknown }).test = originalTest;
+    }
+    expect(labels).toEqual(['should use the global test']);
+  });
+});

--- a/apps/web-ts/tsconfig.json
+++ b/apps/web-ts/tsconfig.json
@@ -20,6 +20,7 @@
         "src/index.ts",
         "src/run.ts",
         "src/run.spec.ts",
+        "src/should-it.spec.ts",
         "src/custom.d.ts"
     ]
 }

--- a/harness/shared/src/index.d.ts
+++ b/harness/shared/src/index.d.ts
@@ -11,3 +11,21 @@ export declare const verify: (
   toEqual: equal;
   toDiffer: equal;
 };
+
+type TestBody = (() => void) | (() => Promise<void>) | undefined;
+type TestFn = (name: string, fn?: TestBody, timeout?: number) => void;
+
+export interface ShouldItChain {
+  then(suite?: TestBody, timeout?: number): ShouldItChain;
+  dont(suite?: TestBody, timeout?: number): ShouldItChain;
+}
+
+export declare const might: (should: boolean) => string;
+export declare const createShouldIt: (
+  testFn: TestFn
+) => (description: string, condition: boolean, toBe?: unknown) => ShouldItChain;
+export declare const shouldIt: (
+  description: string,
+  condition: boolean,
+  toBe?: unknown
+) => ShouldItChain;

--- a/harness/shared/src/index.js
+++ b/harness/shared/src/index.js
@@ -1,10 +1,15 @@
 
+const shouldIt = require('./should-it');
+
 const shared = {
     verify: require('./verify').verify,
     suite: require('./test.suite').suite,
     html: require('./test.suite').html,
     dependencies: require('./dependencies').dependencies,
     versions: require('./deps.json'),
+    might: shouldIt.might,
+    createShouldIt: shouldIt.createShouldIt,
+    shouldIt: shouldIt.shouldIt,
 }
 
 try {

--- a/harness/shared/src/should-it.js
+++ b/harness/shared/src/should-it.js
@@ -1,0 +1,40 @@
+
+const might = (should) => `should${should ? '' : ' not'}`;
+
+const createShouldIt = (testFn) => (description, condition, toBe) => {
+    const tests = {
+        then: (suite, timeout) => {
+            if (condition) {
+                const suffix = toBe ? ` ${JSON.stringify(toBe)}` : '';
+                testFn(`${might(condition)} ${description}${suffix}`, suite, timeout);
+            }
+            return tests;
+        },
+        dont: (suite, timeout) => {
+            if (!condition) testFn(`${might(condition)} ${description}`, suite, timeout);
+            return tests;
+        },
+    };
+    return tests;
+};
+
+const resolveGlobalTest = () => {
+    const t = typeof test === 'function' ? test : (typeof globalThis !== 'undefined' && globalThis.test);
+    if (typeof t !== 'function') {
+        throw new Error("shouldIt: global 'test' not found. Use createShouldIt(testFn) to wire your own runner.");
+    }
+    return t;
+};
+
+const shouldIt = (description, condition, toBe) =>
+    createShouldIt((name, fn, timeout) => resolveGlobalTest()(name, fn, timeout))(description, condition, toBe);
+
+try {
+    module.exports.might = might;
+    module.exports.createShouldIt = createShouldIt;
+    module.exports.shouldIt = shouldIt;
+} catch {
+    window.might = might;
+    window.createShouldIt = createShouldIt;
+    window.shouldIt = shouldIt;
+}


### PR DESCRIPTION
## Summary

- Ships a small, framework-agnostic `shouldIt` test helper at `harness/shared/src/should-it.js` (rather than a published package), consumed across the workspace via `require('shared')`. Exposes `createShouldIt(testFn)` factory, a `shouldIt` global-resolving convenience, and a `might(boolean)` helper.
- Adds parallel TS + CJS jest spec suites in `apps/web-ts` and `apps/web-cs` covering the helper directly (mocked `testFn` for unit coverage + integration with the real jest `test` global).
- Wires shouldIt into the verify/suite custom framework in all three harness apps (`web-cs`, `web-ts`, `web-js`) as a separate `shouldIt verification` suite rendered in `#verification`. The suite proves: (a) `should` / `should not` prefixes, (b) skipped bodies are never invoked, (c) `might()` returns expected strings, (d) the registered test count is exactly 4.
- Advertises the helper in the root README.

## Why

`shouldIt` is a branch-driven naming convention the author has used for years, but it depends on a `test` global being present and isn't trivially portable. The factory pattern lets the same helper work with Jest, Vitest, and the in-repo `verify/suite` framework — proven by being wired into all three concurrently.

## Test plan

- [x] `pnpm run pre-commit` (ws:ts + circularity + lint + root jest 309 tests + harness:test 56 tests)
- [x] `pnpm run harness:build` clean across all three apps
- [x] `docker compose -f harness/docker/docker-compose.yml up -d` — all three URLs serve 200
- [x] Manual: open http://localhost:4114 / :3113 / :2112, confirm `shouldIt verification` section all green with exactly 4 registered tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)